### PR TITLE
feat: terminal-agnostic support and worktree creation

### DIFF
--- a/bin/ghost-tab
+++ b/bin/ghost-tab
@@ -29,6 +29,95 @@ source "$SHARE_DIR/lib/statusline-setup.sh"
 source "$SHARE_DIR/lib/project-actions.sh"
 source "$SHARE_DIR/lib/project-actions-tui.sh"
 
+# ---------- Terminal-only setup ----------
+run_terminal_setup() {
+  local share_dir="$1"
+
+  header "Selecting terminal..."
+  echo ""
+  echo -e "  Ghost Tab supports multiple terminal emulators."
+  echo -e "  Select your preferred terminal:"
+  echo ""
+
+  if select_terminal_interactive; then
+    if [[ -z "$_selected_terminal" ]]; then
+      error "Internal error: TUI did not set terminal"
+      exit 1
+    fi
+    local selected_terminal="$_selected_terminal"
+
+    # Save preference
+    local pref_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab"
+    mkdir -p "$pref_dir"
+    save_terminal_preference "$selected_terminal" "$pref_dir/terminal"
+
+    echo ""
+    success "Selected terminal: $(get_terminal_display_name "$selected_terminal")"
+
+    # Install terminal if needed
+    header "Checking $(get_terminal_display_name "$selected_terminal")..."
+    load_terminal_adapter "$selected_terminal"
+    terminal_install
+
+    # Ensure wrapper symlink exists
+    header "Setting up wrapper script..."
+    local wrapper_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab"
+    mkdir -p "$wrapper_dir"
+    ln -sf "$share_dir/wrapper.sh" "$wrapper_dir/wrapper.sh"
+    success "Linked wrapper.sh in $wrapper_dir/"
+
+    if [ -d "$share_dir/lib" ]; then
+      [ -d "$wrapper_dir/lib" ] && [ ! -L "$wrapper_dir/lib" ] && rm -rf "${wrapper_dir:?}/lib"
+      ln -sfn "$share_dir/lib" "$wrapper_dir/lib"
+    fi
+
+    # Configure terminal
+    header "Setting up $(get_terminal_display_name "$selected_terminal") config..."
+    local terminal_config
+    terminal_config="$(terminal_get_config_path)"
+    local wrapper_path
+    wrapper_path="$(terminal_get_wrapper_path)"
+
+    if [ -f "$terminal_config" ]; then
+      warn "Existing config found at $terminal_config"
+      echo ""
+      echo -e "  ${_BOLD}1)${_NC} Merge — add the wrapper command to your existing config"
+      echo -e "  ${_BOLD}2)${_NC} Skip — don't modify the config (manual setup required)"
+      echo ""
+      read -rn1 -p "$(echo -e "${_BLUE}Choose (1/2):${_NC} ")" config_choice </dev/tty
+      echo ""
+
+      case "$config_choice" in
+        1) terminal_setup_config "$terminal_config" "$wrapper_path" ;;
+        *) info "Skipped config modification. Add the wrapper manually." ;;
+      esac
+    else
+      mkdir -p "$(dirname "$terminal_config")"
+      terminal_setup_config "$terminal_config" "$wrapper_path"
+    fi
+
+    echo ""
+    success "Terminal configured: $(get_terminal_display_name "$selected_terminal")"
+    info "Open a new $(get_terminal_display_name "$selected_terminal") window to start coding."
+  else
+    info "Terminal selection cancelled"
+    exit 1
+  fi
+}
+
+# ---------- Argument parsing ----------
+case "${1:-}" in
+  --terminal)
+    run_terminal_setup "$SHARE_DIR"
+    exit 0
+    ;;
+  --*)
+    error "Unknown flag: $1"
+    echo "Usage: ghost-tab [--terminal]"
+    exit 1
+    ;;
+esac
+
 # ---------- OS check ----------
 header "Checking platform..."
 if [ "$(uname)" != "Darwin" ]; then

--- a/bin/ghost-tab
+++ b/bin/ghost-tab
@@ -20,7 +20,9 @@ fi
 
 source "$SHARE_DIR/lib/tui.sh"
 source "$SHARE_DIR/lib/install.sh"
-source "$SHARE_DIR/lib/ghostty-config.sh"
+source "$SHARE_DIR/lib/terminal-select-tui.sh"
+source "$SHARE_DIR/lib/terminals/registry.sh"
+source "$SHARE_DIR/lib/terminals/adapter.sh"
 source "$SHARE_DIR/lib/settings-json.sh"
 source "$SHARE_DIR/lib/ai-select-tui.sh"
 source "$SHARE_DIR/lib/statusline-setup.sh"
@@ -86,7 +88,7 @@ if select_ai_tool_interactive; then
   case "$SELECTED_AI_TOOL" in
     claude)
       ensure_command "claude" "curl -fsSL https://claude.ai/install.sh | bash" \
-        "Run 'claude' to authenticate before opening Ghostty." "Claude Code"
+        "Run 'claude' to authenticate before launching Ghost Tab." "Claude Code"
       ;;
     codex)
       ensure_command "codex" "brew install --cask codex" "" "Codex CLI"
@@ -103,12 +105,39 @@ else
   exit 1
 fi
 
-# ---------- Ghostty ----------
-header "Checking Ghostty..."
-ensure_cask "ghostty" "Ghostty"
+# ---------- Terminal Selection ----------
+header "Selecting terminal..."
+echo ""
+echo -e "  Ghost Tab supports multiple terminal emulators."
+echo -e "  Select your preferred terminal:"
+echo ""
 
-# Verify supporting files exist (will fail if run via curl|bash without clone)
-if [ ! -f "$SHARE_DIR/ghostty/claude-wrapper.sh" ] || [ ! -f "$SHARE_DIR/ghostty/config" ] || [ ! -d "$SHARE_DIR/templates" ]; then
+if select_terminal_interactive; then
+  if [[ -z "$_selected_terminal" ]]; then
+    error "Internal error: TUI did not set terminal"
+    exit 1
+  fi
+  SELECTED_TERMINAL="$_selected_terminal"
+
+  # Save preference
+  TERMINAL_PREF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab"
+  mkdir -p "$TERMINAL_PREF_DIR"
+  save_terminal_preference "$SELECTED_TERMINAL" "$TERMINAL_PREF_DIR/terminal"
+
+  echo ""
+  success "Selected terminal: $(get_terminal_display_name "$SELECTED_TERMINAL")"
+else
+  info "Terminal selection cancelled"
+  exit 1
+fi
+
+# ---------- Terminal Installation ----------
+header "Checking $(get_terminal_display_name "$SELECTED_TERMINAL")..."
+load_terminal_adapter "$SELECTED_TERMINAL"
+terminal_install
+
+# Verify supporting files exist
+if [ ! -f "$SHARE_DIR/wrapper.sh" ] || [ ! -d "$SHARE_DIR/templates" ]; then
   error "Supporting files not found in $SHARE_DIR"
   echo ""
   info "If you ran this via curl|bash, install via Homebrew instead:"
@@ -121,41 +150,41 @@ if [ ! -f "$SHARE_DIR/ghostty/claude-wrapper.sh" ] || [ ! -f "$SHARE_DIR/ghostty
   exit 1
 fi
 
-# ---------- Wrapper script ----------
+# ---------- Wrapper Script ----------
 header "Setting up wrapper script..."
-mkdir -p ~/.config/ghostty
-ln -sf "$SHARE_DIR/ghostty/claude-wrapper.sh" ~/.config/ghostty/claude-wrapper.sh
-success "Linked claude-wrapper.sh in ~/.config/ghostty/"
+WRAPPER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab"
+mkdir -p "$WRAPPER_DIR"
+ln -sf "$SHARE_DIR/wrapper.sh" "$WRAPPER_DIR/wrapper.sh"
+success "Linked wrapper.sh in $WRAPPER_DIR/"
 
 # Symlink shared libraries (remove old copies if present)
 if [ -d "$SHARE_DIR/lib" ]; then
-  [ -d ~/.config/ghostty/lib ] && [ ! -L ~/.config/ghostty/lib ] && rm -rf ~/.config/ghostty/lib
-  ln -sfn "$SHARE_DIR/lib" ~/.config/ghostty/lib
-  success "Linked shared libraries to ~/.config/ghostty/lib/"
+  [ -d "$WRAPPER_DIR/lib" ] && [ ! -L "$WRAPPER_DIR/lib" ] && rm -rf "${WRAPPER_DIR:?}/lib"
+  ln -sfn "$SHARE_DIR/lib" "$WRAPPER_DIR/lib"
+  success "Linked shared libraries to $WRAPPER_DIR/lib/"
 fi
 
-# ---------- Ghostty config ----------
-header "Setting up Ghostty config..."
-GHOSTTY_CONFIG="$HOME/.config/ghostty/config"
-WRAPPER_LINE="command = ~/.config/ghostty/claude-wrapper.sh"
+# ---------- Terminal Config ----------
+header "Setting up $(get_terminal_display_name "$SELECTED_TERMINAL") config..."
+TERMINAL_CONFIG="$(terminal_get_config_path)"
+WRAPPER_PATH="$(terminal_get_wrapper_path)"
 
-if [ -f "$GHOSTTY_CONFIG" ]; then
-  warn "Existing Ghostty config found at $GHOSTTY_CONFIG"
+if [ -f "$TERMINAL_CONFIG" ]; then
+  warn "Existing config found at $TERMINAL_CONFIG"
   echo ""
   echo -e "  ${_BOLD}1)${_NC} Merge — add the wrapper command to your existing config"
-  echo -e "  ${_BOLD}2)${_NC} Backup & replace — save current config and use ours"
+  echo -e "  ${_BOLD}2)${_NC} Skip — don't modify the config (manual setup required)"
   echo ""
   read -rn1 -p "$(echo -e "${_BLUE}Choose (1/2):${_NC} ")" config_choice </dev/tty
   echo ""
 
   case "$config_choice" in
-    1) merge_ghostty_config "$GHOSTTY_CONFIG" "$WRAPPER_LINE" ;;
-    2) backup_replace_ghostty_config "$GHOSTTY_CONFIG" "$SHARE_DIR/ghostty/config" ;;
-    *) warn "Invalid choice, skipping config setup" ;;
+    1) terminal_setup_config "$TERMINAL_CONFIG" "$WRAPPER_PATH" ;;
+    *) info "Skipped config modification. Add the wrapper manually." ;;
   esac
 else
-  cp "$SHARE_DIR/ghostty/config" "$GHOSTTY_CONFIG"
-  success "Created Ghostty config at $GHOSTTY_CONFIG"
+  mkdir -p "$(dirname "$TERMINAL_CONFIG")"
+  terminal_setup_config "$TERMINAL_CONFIG" "$WRAPPER_PATH"
 fi
 
 # Migrate from old config location
@@ -164,6 +193,17 @@ NEW_PROJECTS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab"
 if [ -d "$OLD_PROJECTS_DIR" ] && [ ! -d "$NEW_PROJECTS_DIR" ]; then
   mv "$OLD_PROJECTS_DIR" "$NEW_PROJECTS_DIR"
   info "Migrated config from vibecode-editor to ghost-tab"
+fi
+
+# Detect legacy Ghostty-only installation
+if [ -z "${SELECTED_TERMINAL:-}" ]; then
+  if [ -f "$HOME/.config/ghostty/claude-wrapper.sh" ] || [ -L "$HOME/.config/ghostty/claude-wrapper.sh" ]; then
+    TERMINAL_PREF_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/terminal"
+    if [ ! -f "$TERMINAL_PREF_FILE" ]; then
+      info "Detected legacy Ghostty setup, migrating..."
+      save_terminal_preference "ghostty" "$TERMINAL_PREF_FILE"
+    fi
+  fi
 fi
 
 # ---------- Projects ----------
@@ -225,8 +265,9 @@ fi
 # ---------- Summary ----------
 header "Setup complete!"
 echo ""
-success "Wrapper script:  ~/.config/ghostty/claude-wrapper.sh (symlink)"
-success "Ghostty config:  ~/.config/ghostty/config"
+success "Wrapper script:  ~/.config/ghost-tab/wrapper.sh (symlink)"
+_terminal_pref="$(cat "${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/terminal" 2>/dev/null)"
+success "Terminal:        $(get_terminal_display_name "$_terminal_pref")"
 _ai_default="$(cat "${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/ai-tool" 2>/dev/null)"
 success "AI tool:         $(echo "$_ai_default" | sed 's/claude/Claude Code/;s/codex/Codex CLI/;s/copilot/Copilot CLI/;s/opencode/OpenCode/')"
 success "Projects file:   $PROJECTS_FILE"
@@ -240,7 +281,7 @@ if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/opencode/plugins/ghost-tab.ts" ]; the
   success "OpenCode plugin: ~/.config/opencode/plugins/ghost-tab.ts"
 fi
 echo ""
-info "Open a new Ghostty window to start coding."
+info "Open a new $(get_terminal_display_name "${SELECTED_TERMINAL:-$_terminal_pref}") window to start coding."
 
 } # end main
 

--- a/cmd/ghost-tab-tui/cmd_test.go
+++ b/cmd/ghost-tab-tui/cmd_test.go
@@ -32,6 +32,7 @@ func TestRootCmd_SubcommandRegistered(t *testing.T) {
 		"main-menu",
 		"multi-select-ai-tool",
 		"select-branch",
+		"select-terminal",
 	}
 
 	for _, name := range subcommands {
@@ -226,6 +227,16 @@ func TestSelectAIToolCmd_Exists(t *testing.T) {
 	}
 	if cmd.Name() != "select-ai-tool" {
 		t.Errorf("Expected 'select-ai-tool', got %q", cmd.Name())
+	}
+}
+
+func TestSelectTerminalCmd_Exists(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"select-terminal"})
+	if err != nil {
+		t.Fatalf("Failed to find select-terminal: %v", err)
+	}
+	if cmd.Name() != "select-terminal" {
+		t.Errorf("Expected 'select-terminal', got %q", cmd.Name())
 	}
 }
 

--- a/cmd/ghost-tab-tui/select_branch.go
+++ b/cmd/ghost-tab-tui/select_branch.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jackuait/ghost-tab/internal/models"
+	"github.com/jackuait/ghost-tab/internal/tui"
+	"github.com/jackuait/ghost-tab/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var selectBranchCmd = &cobra.Command{
+	Use:   "select-branch",
+	Short: "Interactive branch selector for worktree creation",
+	Long:  "Shows a filterable list of branches and returns the selected branch as JSON",
+	RunE:  runSelectBranch,
+}
+
+var projectPathFlag string
+
+func init() {
+	selectBranchCmd.Flags().StringVar(&projectPathFlag, "project-path", "", "Path to the git project")
+	selectBranchCmd.MarkFlagRequired("project-path")
+	rootCmd.AddCommand(selectBranchCmd)
+}
+
+func runSelectBranch(cmd *cobra.Command, args []string) error {
+	tui.ApplyTheme(tui.ThemeForTool(aiToolFlag))
+
+	// Get main branch name from worktree porcelain output
+	wtCmd := exec.Command("git", "-C", projectPathFlag, "worktree", "list", "--porcelain")
+	wtOut, _ := wtCmd.Output()
+	mainBranch := models.ParseMainBranch(string(wtOut))
+
+	// List all branches
+	branches := models.ListBranches(projectPathFlag)
+	if len(branches) == 0 {
+		result := map[string]interface{}{"selected": false}
+		jsonOutput, _ := json.Marshal(result)
+		fmt.Println(string(jsonOutput))
+		return nil
+	}
+
+	// Get existing worktrees to filter out
+	worktrees := models.DetectWorktrees(projectPathFlag)
+
+	// Filter out taken branches
+	available := models.FilterAvailableBranches(branches, worktrees, mainBranch)
+	if len(available) == 0 {
+		result := map[string]interface{}{"selected": false}
+		jsonOutput, _ := json.Marshal(result)
+		fmt.Println(string(jsonOutput))
+		return nil
+	}
+
+	model := tui.NewBranchPicker(available)
+
+	ttyOpts, cleanup, err := util.TUITeaOptions()
+	if err != nil {
+		return fmt.Errorf("failed to run TUI: %w", err)
+	}
+	defer cleanup()
+
+	opts := append([]tea.ProgramOption{tea.WithAltScreen()}, ttyOpts...)
+	p := tea.NewProgram(model, opts...)
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run TUI: %w", err)
+	}
+
+	m := finalModel.(tui.BranchPickerModel)
+	selected := m.Selected()
+
+	var result map[string]interface{}
+	if selected != nil {
+		result = map[string]interface{}{
+			"branch":   *selected,
+			"selected": true,
+		}
+	} else {
+		result = map[string]interface{}{"selected": false}
+	}
+
+	jsonOutput, _ := json.Marshal(result)
+	fmt.Println(string(jsonOutput))
+	return nil
+}

--- a/cmd/ghost-tab-tui/select_branch.go
+++ b/cmd/ghost-tab-tui/select_branch.go
@@ -28,7 +28,8 @@ func init() {
 }
 
 func runSelectBranch(cmd *cobra.Command, args []string) error {
-	tui.ApplyTheme(tui.ThemeForTool(aiToolFlag))
+	theme := tui.ThemeForTool(aiToolFlag)
+	tui.ApplyTheme(theme)
 
 	// Get main branch name from worktree porcelain output
 	wtCmd := exec.Command("git", "-C", projectPathFlag, "worktree", "list", "--porcelain")
@@ -56,7 +57,7 @@ func runSelectBranch(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	model := tui.NewBranchPicker(available)
+	model := tui.NewBranchPicker(available, theme, projectPathFlag)
 
 	ttyOpts, cleanup, err := util.TUITeaOptions()
 	if err != nil {

--- a/cmd/ghost-tab-tui/select_terminal.go
+++ b/cmd/ghost-tab-tui/select_terminal.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jackuait/ghost-tab/internal/models"
+	"github.com/jackuait/ghost-tab/internal/tui"
+	"github.com/jackuait/ghost-tab/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var selectTerminalCmd = &cobra.Command{
+	Use:   "select-terminal",
+	Short: "Interactive terminal emulator selector",
+	Long:  "Shows available terminal emulators and returns selected terminal as JSON",
+	RunE:  runSelectTerminal,
+}
+
+func init() {
+	rootCmd.AddCommand(selectTerminalCmd)
+}
+
+func runSelectTerminal(cmd *cobra.Command, args []string) error {
+	tui.ApplyTheme(tui.ThemeForTool(aiToolFlag))
+
+	terminals := models.DetectTerminals()
+
+	model := tui.NewTerminalSelector(terminals)
+
+	ttyOpts, cleanup, err := util.TUITeaOptions()
+	if err != nil {
+		return fmt.Errorf("failed to run TUI: %w", err)
+	}
+	defer cleanup()
+
+	opts := append([]tea.ProgramOption{tea.WithAltScreen()}, ttyOpts...)
+	p := tea.NewProgram(model, opts...)
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run TUI: %w", err)
+	}
+
+	m := finalModel.(tui.TerminalSelectorModel)
+	selected := m.Selected()
+
+	var result map[string]interface{}
+	if selected != nil {
+		result = map[string]interface{}{
+			"terminal": selected.Name,
+			"selected": true,
+		}
+	} else {
+		result = map[string]interface{}{"selected": false}
+	}
+
+	jsonOutput, _ := json.Marshal(result)
+	fmt.Println(string(jsonOutput))
+
+	return nil
+}

--- a/ghostty/claude-wrapper.sh
+++ b/ghostty/claude-wrapper.sh
@@ -142,6 +142,10 @@ elif [ -z "$1" ]; then
         plain-terminal)
           exec "$SHELL"
           ;;
+        add-worktree)
+          # Loop back to menu — worktrees refresh on reload
+          continue
+          ;;
         *)
           # settings or unknown — loop back to menu
           continue

--- a/internal/models/terminal.go
+++ b/internal/models/terminal.go
@@ -1,0 +1,44 @@
+package models
+
+import "os"
+
+// Terminal represents a supported terminal emulator
+type Terminal struct {
+	Name        string
+	DisplayName string
+	CaskName    string
+	AppName     string // For /Applications check (macOS)
+	Installed   bool
+}
+
+// String returns display string for terminal
+func (t Terminal) String() string {
+	if t.Installed {
+		return t.DisplayName + " ✓"
+	}
+	return t.DisplayName + " (not installed)"
+}
+
+// SupportedTerminals returns the list of terminals Ghost Tab can configure
+func SupportedTerminals() []Terminal {
+	return []Terminal{
+		{Name: "ghostty", DisplayName: "Ghostty", CaskName: "ghostty", AppName: "Ghostty"},
+		{Name: "iterm2", DisplayName: "iTerm2", CaskName: "iterm2", AppName: "iTerm"},
+		{Name: "wezterm", DisplayName: "WezTerm", CaskName: "wezterm", AppName: "WezTerm"},
+		{Name: "kitty", DisplayName: "kitty", CaskName: "kitty", AppName: "kitty"},
+	}
+}
+
+// DetectTerminals checks which terminals are installed
+func DetectTerminals() []Terminal {
+	terminals := SupportedTerminals()
+	for i := range terminals {
+		terminals[i].Installed = isAppInstalled(terminals[i].AppName)
+	}
+	return terminals
+}
+
+func isAppInstalled(appName string) bool {
+	_, err := os.Stat("/Applications/" + appName + ".app")
+	return err == nil
+}

--- a/internal/models/worktree.go
+++ b/internal/models/worktree.go
@@ -131,3 +131,23 @@ func ListBranches(projectPath string) []string {
 	}
 	return ParseBranchList(string(out))
 }
+
+// FilterAvailableBranches removes branches that already have worktrees and
+// the main branch. Returns nil if no branches remain.
+func FilterAvailableBranches(branches []string, worktrees []Worktree, mainBranch string) []string {
+	taken := make(map[string]bool)
+	if mainBranch != "" {
+		taken[mainBranch] = true
+	}
+	for _, wt := range worktrees {
+		taken[wt.Branch] = true
+	}
+
+	var result []string
+	for _, b := range branches {
+		if !taken[b] {
+			result = append(result, b)
+		}
+	}
+	return result
+}

--- a/internal/models/worktree.go
+++ b/internal/models/worktree.go
@@ -151,3 +151,22 @@ func FilterAvailableBranches(branches []string, worktrees []Worktree, mainBranch
 	}
 	return result
 }
+
+// ParseMainBranch extracts the branch name of the main worktree (first entry)
+// from `git worktree list --porcelain` output. Returns "" if not found.
+func ParseMainBranch(output string) string {
+	if output == "" {
+		return ""
+	}
+	blocks := strings.Split(strings.TrimRight(output, "\n"), "\n\n")
+	if len(blocks) == 0 {
+		return ""
+	}
+	for _, line := range strings.Split(blocks[0], "\n") {
+		if strings.HasPrefix(line, "branch ") {
+			ref := strings.TrimPrefix(line, "branch ")
+			return strings.TrimPrefix(ref, "refs/heads/")
+		}
+	}
+	return ""
+}

--- a/internal/models/worktree.go
+++ b/internal/models/worktree.go
@@ -142,6 +142,11 @@ func FilterAvailableBranches(branches []string, worktrees []Worktree, mainBranch
 	for _, wt := range worktrees {
 		taken[wt.Branch] = true
 	}
+	// Always exclude default branch names
+	taken["main"] = true
+	taken["master"] = true
+	taken["origin/main"] = true
+	taken["origin/master"] = true
 
 	var result []string
 	for _, b := range branches {
@@ -150,6 +155,19 @@ func FilterAvailableBranches(branches []string, worktrees []Worktree, mainBranch
 		}
 	}
 	return result
+}
+
+// DeleteBranch deletes a git branch. Local branches are force-deleted with
+// `git branch -D`. Remote branches (origin/ prefix) are deleted with
+// `git push origin --delete`.
+func DeleteBranch(projectPath, branch string) error {
+	if strings.HasPrefix(branch, "origin/") {
+		name := strings.TrimPrefix(branch, "origin/")
+		cmd := exec.Command("git", "-C", projectPath, "push", "origin", "--delete", name)
+		return cmd.Run()
+	}
+	cmd := exec.Command("git", "-C", projectPath, "branch", "-D", branch)
+	return cmd.Run()
 }
 
 // ParseMainBranch extracts the branch name of the main worktree (first entry)

--- a/internal/tui/branches.go
+++ b/internal/tui/branches.go
@@ -1,37 +1,52 @@
 package tui
 
 import (
-	"github.com/charmbracelet/bubbles/list"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jackuait/ghost-tab/internal/models"
 )
 
-type branchItem struct {
-	name string
+// BranchDeletedMsg is sent after an async branch deletion completes.
+type BranchDeletedMsg struct {
+	Branch string
+	Err    error
 }
-
-func (i branchItem) Title() string       { return i.name }
-func (i branchItem) Description() string { return "" }
-func (i branchItem) FilterValue() string { return i.name }
 
 // BranchPickerModel lets the user pick a branch from a filterable list.
+// It renders with box-drawing borders matching the main menu style.
 type BranchPickerModel struct {
-	list     list.Model
-	selected *string
-	quitting bool
+	allBranches    []string
+	filtered       []string
+	filtering      bool   // whether filter mode is active (activated by '/')
+	filterText     string
+	cursor         int // index in filtered list
+	offset         int // scroll offset for visible window
+	selected       *string
+	quitting       bool
+	width          int
+	height         int
+	theme          AIToolTheme
+	projectPath    string
+	deleteMode     bool
+	deleteSelected int
+	deleteOffset   int
+	feedback       string
+	feedbackIsErr  bool
 }
 
-// NewBranchPicker creates a branch picker with the given branch names.
-func NewBranchPicker(branches []string) BranchPickerModel {
-	items := make([]list.Item, len(branches))
-	for i, b := range branches {
-		items[i] = branchItem{name: b}
+// NewBranchPicker creates a branch picker with the given branch names, theme, and project path.
+func NewBranchPicker(branches []string, theme AIToolTheme, projectPath string) BranchPickerModel {
+	filtered := make([]string, len(branches))
+	copy(filtered, branches)
+
+	return BranchPickerModel{
+		allBranches: branches,
+		filtered:    filtered,
+		theme:       theme,
+		projectPath: projectPath,
 	}
-
-	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "Select Branch"
-	l.Styles.Title = titleStyle
-
-	return BranchPickerModel{list: l}
 }
 
 func (m BranchPickerModel) Init() tea.Cmd {
@@ -41,35 +56,503 @@ func (m BranchPickerModel) Init() tea.Cmd {
 func (m BranchPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.list.SetWidth(msg.Width)
-		m.list.SetHeight(msg.Height - 2)
+		m.width = msg.Width
+		m.height = msg.Height
+		m.clampScroll()
+		return m, nil
+
+	case BranchDeletedMsg:
+		m.deleteMode = false
+		if msg.Err != nil {
+			m.feedback = msg.Err.Error()
+			m.feedbackIsErr = true
+		} else {
+			m.feedback = "Deleted " + msg.Branch
+			m.feedbackIsErr = false
+			m.removeBranch(msg.Branch)
+		}
 		return m, nil
 
 	case tea.KeyMsg:
+		// Clear feedback on any keypress after deletion
+		if m.feedback != "" {
+			m.feedback = ""
+			m.feedbackIsErr = false
+			return m, nil
+		}
+
+		if m.deleteMode {
+			return m.updateDeleteMode(msg)
+		}
+
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
+			if m.filtering {
+				m.filtering = false
+				m.filterText = ""
+				m.applyFilter()
+				return m, nil
+			}
 			m.quitting = true
 			return m, tea.Quit
+
 		case tea.KeyEnter:
-			if item, ok := m.list.SelectedItem().(branchItem); ok {
-				name := item.name
+			if len(m.filtered) > 0 && m.cursor < len(m.filtered) {
+				name := m.filtered[m.cursor]
 				m.selected = &name
 			}
 			m.quitting = true
 			return m, tea.Quit
+
+		case tea.KeyUp:
+			if m.cursor > 0 {
+				m.cursor--
+				m.clampScroll()
+			}
+			return m, nil
+
+		case tea.KeyDown:
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+				m.clampScroll()
+			}
+			return m, nil
+
+		case tea.KeyBackspace:
+			if m.filtering && len(m.filterText) > 0 {
+				m.filterText = m.filterText[:len(m.filterText)-1]
+				m.applyFilter()
+			}
+			return m, nil
+
+		case tea.KeyRunes:
+			r := msg.Runes[0]
+			// '/' activates filter mode
+			if !m.filtering && r == '/' {
+				m.filtering = true
+				return m, nil
+			}
+			// When not filtering, handle command keys
+			if !m.filtering {
+				if r == 'k' {
+					if m.cursor > 0 {
+						m.cursor--
+						m.clampScroll()
+					}
+					return m, nil
+				}
+				if r == 'j' {
+					if m.cursor < len(m.filtered)-1 {
+						m.cursor++
+						m.clampScroll()
+					}
+					return m, nil
+				}
+				if r == 'd' && len(m.filtered) > 0 {
+					m.deleteMode = true
+					m.deleteSelected = 0
+					return m, nil
+				}
+				return m, nil
+			}
+			// In filter mode, add to filter text
+			m.filterText += string(msg.Runes)
+			m.applyFilter()
+			return m, nil
 		}
 	}
 
-	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
-	return m, cmd
+	return m, nil
+}
+
+func (m BranchPickerModel) updateDeleteMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc, tea.KeyCtrlC:
+		m.deleteMode = false
+		return m, nil
+
+	case tea.KeyUp:
+		if m.deleteSelected > 0 {
+			m.deleteSelected--
+		} else {
+			m.deleteSelected = len(m.allBranches) - 1
+		}
+		m.clampDeleteScroll()
+		return m, nil
+
+	case tea.KeyDown:
+		if m.deleteSelected < len(m.allBranches)-1 {
+			m.deleteSelected++
+		} else {
+			m.deleteSelected = 0
+		}
+		m.clampDeleteScroll()
+		return m, nil
+
+	case tea.KeyEnter:
+		if m.deleteSelected < len(m.allBranches) {
+			branch := m.allBranches[m.deleteSelected]
+			projectPath := m.projectPath
+			return m, func() tea.Msg {
+				err := models.DeleteBranch(projectPath, branch)
+				return BranchDeletedMsg{Branch: branch, Err: err}
+			}
+		}
+		return m, nil
+
+	case tea.KeyRunes:
+		r := msg.Runes[0]
+		switch {
+		case r == 'q' || r == 'Q':
+			m.deleteMode = false
+			return m, nil
+		case r == 'k':
+			if m.deleteSelected > 0 {
+				m.deleteSelected--
+			} else {
+				m.deleteSelected = len(m.allBranches) - 1
+			}
+			m.clampDeleteScroll()
+			return m, nil
+		case r == 'j':
+			if m.deleteSelected < len(m.allBranches)-1 {
+				m.deleteSelected++
+			} else {
+				m.deleteSelected = 0
+			}
+			m.clampDeleteScroll()
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m *BranchPickerModel) removeBranch(branch string) {
+	var newAll []string
+	for _, b := range m.allBranches {
+		if b != branch {
+			newAll = append(newAll, b)
+		}
+	}
+	m.allBranches = newAll
+	m.applyFilter()
+	if m.cursor >= len(m.filtered) && m.cursor > 0 {
+		m.cursor = len(m.filtered) - 1
+	}
+	m.clampScroll()
+}
+
+func (m *BranchPickerModel) applyFilter() {
+	if m.filterText == "" {
+		m.filtered = make([]string, len(m.allBranches))
+		copy(m.filtered, m.allBranches)
+	} else {
+		lower := strings.ToLower(m.filterText)
+		m.filtered = nil
+		for _, b := range m.allBranches {
+			if strings.Contains(strings.ToLower(b), lower) {
+				m.filtered = append(m.filtered, b)
+			}
+		}
+	}
+	m.cursor = 0
+	m.offset = 0
+}
+
+func (m *BranchPickerModel) clampScroll() {
+	visible := m.visibleItemCount()
+	if visible <= 0 {
+		return
+	}
+	if m.cursor < m.offset {
+		m.offset = m.cursor
+	}
+	if m.cursor >= m.offset+visible {
+		m.offset = m.cursor - visible + 1
+	}
+}
+
+// visibleItemCount returns how many branch items fit in the select box.
+// Box layout: top border, title row, separator, filter row, empty row,
+// ... items ..., empty row, separator, help row, bottom border.
+// That's 9 fixed rows. Items get the rest.
+func (m BranchPickerModel) visibleItemCount() int {
+	count := m.height - 9
+	if count < 1 {
+		count = 1
+	}
+	return count
+}
+
+// deleteVisibleCount returns how many branch items fit in the delete box.
+// Box layout: top border, title row, separator, empty row,
+// ... items ..., empty row, separator, help row, bottom border.
+// That's 8 fixed rows. Items get the rest.
+func (m BranchPickerModel) deleteVisibleCount() int {
+	count := m.height - 8
+	if count < 1 {
+		count = 1
+	}
+	return count
+}
+
+func (m *BranchPickerModel) clampDeleteScroll() {
+	visible := m.deleteVisibleCount()
+	if visible <= 0 {
+		return
+	}
+	if m.deleteSelected < m.deleteOffset {
+		m.deleteOffset = m.deleteSelected
+	}
+	if m.deleteSelected >= m.deleteOffset+visible {
+		m.deleteOffset = m.deleteSelected - visible + 1
+	}
 }
 
 func (m BranchPickerModel) View() string {
 	if m.quitting {
 		return ""
 	}
-	return m.list.View()
+
+	if m.deleteMode {
+		return m.renderDeleteBox()
+	}
+
+	return m.renderSelectBox()
+}
+
+func (m BranchPickerModel) renderSelectBox() string {
+	dimStyle := lipgloss.NewStyle().Foreground(m.theme.Dim)
+	primaryStyle := lipgloss.NewStyle().Foreground(m.theme.Primary)
+	primaryBoldStyle := lipgloss.NewStyle().Foreground(m.theme.Primary).Bold(true)
+	textStyle := lipgloss.NewStyle().Foreground(m.theme.Text)
+	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("247"))
+	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	successStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("76"))
+
+	hLine := strings.Repeat("\u2500", menuInnerWidth)
+	topBorder := dimStyle.Render("\u250c" + hLine + "\u2510")
+	separator := dimStyle.Render("\u251c" + hLine + "\u2524")
+	bottomBorder := dimStyle.Render("\u2514" + hLine + "\u2518")
+	leftBorder := dimStyle.Render("\u2502")
+	rightBorder := dimStyle.Render("\u2502")
+
+	emptyRow := leftBorder + strings.Repeat(" ", menuInnerWidth) + rightBorder
+
+	var lines []string
+
+	// Top border
+	lines = append(lines, topBorder)
+
+	// Title row
+	title := primaryBoldStyle.Render("\u2b21  Select Branch")
+	titlePadding := menuInnerWidth - lipgloss.Width(title) - 1
+	if titlePadding < 0 {
+		titlePadding = 0
+	}
+	lines = append(lines, leftBorder+" "+title+strings.Repeat(" ", titlePadding)+rightBorder)
+
+	// Separator
+	lines = append(lines, separator)
+
+	// Filter row
+	var filterContent string
+	if m.filtering {
+		filterPrompt := dimStyle.Render("/")
+		if m.filterText == "" {
+			filterContent = "  " + filterPrompt + " " + dimStyle.Render("type to filter...") + dimStyle.Render("│")
+		} else {
+			filterContent = "  " + filterPrompt + " " + textStyle.Render(m.filterText) + dimStyle.Render("│")
+		}
+	} else {
+		filterContent = "  " + dimStyle.Render("/ to filter")
+	}
+	filterPadding := menuInnerWidth - lipgloss.Width(filterContent)
+	if filterPadding < 0 {
+		filterPadding = 0
+	}
+	lines = append(lines, leftBorder+filterContent+strings.Repeat(" ", filterPadding)+rightBorder)
+
+	// Empty line before items
+	lines = append(lines, emptyRow)
+
+	// Branch items
+	visible := m.visibleItemCount()
+	if len(m.filtered) == 0 {
+		noItems := "  " + dimStyle.Render("No matching branches")
+		noItemsPadding := menuInnerWidth - lipgloss.Width(noItems)
+		if noItemsPadding < 0 {
+			noItemsPadding = 0
+		}
+		lines = append(lines, leftBorder+noItems+strings.Repeat(" ", noItemsPadding)+rightBorder)
+	} else {
+		end := m.offset + visible
+		if end > len(m.filtered) {
+			end = len(m.filtered)
+		}
+		for i := m.offset; i < end; i++ {
+			branch := m.filtered[i]
+			selected := i == m.cursor
+
+			truncBranch := TruncateMiddle(branch, menuInnerWidth-7)
+
+			var row string
+			if selected {
+				marker := primaryBoldStyle.Render("\u258e")
+				branchText := primaryBoldStyle.Render(truncBranch)
+				content := "  " + marker + " " + branchText
+				padding := menuInnerWidth - lipgloss.Width(content)
+				if padding < 0 {
+					padding = 0
+				}
+				row = leftBorder + content + strings.Repeat(" ", padding) + rightBorder
+			} else {
+				branchText := primaryStyle.Render(truncBranch)
+				content := "    " + branchText
+				padding := menuInnerWidth - lipgloss.Width(content)
+				if padding < 0 {
+					padding = 0
+				}
+				row = leftBorder + content + strings.Repeat(" ", padding) + rightBorder
+			}
+			lines = append(lines, row)
+		}
+	}
+
+	// Empty line after items
+	lines = append(lines, emptyRow)
+
+	// Separator before help
+	lines = append(lines, separator)
+
+	// Help row
+	var helpContent string
+	if m.feedback != "" {
+		if m.feedbackIsErr {
+			helpContent = errorStyle.Render(m.feedback)
+		} else {
+			helpContent = successStyle.Render(m.feedback)
+		}
+	} else {
+		helpText := "\u2191/k up \u00b7 \u2193/j down \u00b7 enter select \u00b7 / filter \u00b7 d delete \u00b7 esc back"
+		helpContent = helpStyle.Render(helpText)
+	}
+	helpPadding := menuInnerWidth - lipgloss.Width(helpContent) - 1
+	if helpPadding < 0 {
+		helpPadding = 0
+	}
+	lines = append(lines, leftBorder+" "+helpContent+strings.Repeat(" ", helpPadding)+rightBorder)
+
+	// Bottom border
+	lines = append(lines, bottomBorder)
+
+	return m.centerBox(lines)
+}
+
+func (m BranchPickerModel) renderDeleteBox() string {
+	dimStyle := lipgloss.NewStyle().Foreground(m.theme.Dim)
+	primaryBoldStyle := lipgloss.NewStyle().Foreground(m.theme.Primary).Bold(true)
+	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("247"))
+	deleteHighlight := lipgloss.NewStyle().Background(lipgloss.Color("196")).Foreground(lipgloss.Color("15"))
+
+	hLine := strings.Repeat("\u2500", menuInnerWidth)
+	topBorder := dimStyle.Render("\u250c" + hLine + "\u2510")
+	separator := dimStyle.Render("\u251c" + hLine + "\u2524")
+	bottomBorder := dimStyle.Render("\u2514" + hLine + "\u2518")
+	leftBorder := dimStyle.Render("\u2502")
+	rightBorder := dimStyle.Render("\u2502")
+	emptyRow := leftBorder + strings.Repeat(" ", menuInnerWidth) + rightBorder
+
+	var lines []string
+
+	lines = append(lines, topBorder)
+
+	// Title row with "· Delete" suffix
+	title := primaryBoldStyle.Render("\u2b21  Select Branch")
+	titleContent := title + " " + dimStyle.Render("\u00b7 Delete")
+	titlePadding := menuInnerWidth - lipgloss.Width(titleContent) - 1
+	if titlePadding < 0 {
+		titlePadding = 0
+	}
+	lines = append(lines, leftBorder+" "+titleContent+strings.Repeat(" ", titlePadding)+rightBorder)
+	lines = append(lines, separator)
+	lines = append(lines, emptyRow)
+
+	// Branch items — selected in red highlight, others dimmed
+	visible := m.deleteVisibleCount()
+	end := m.deleteOffset + visible
+	if end > len(m.allBranches) {
+		end = len(m.allBranches)
+	}
+	for i := m.deleteOffset; i < end; i++ {
+		branch := m.allBranches[i]
+		selected := m.deleteSelected == i
+		truncBranch := TruncateMiddle(branch, menuInnerWidth-6)
+
+		var row string
+		if selected {
+			nameText := deleteHighlight.Render(" " + truncBranch + " ")
+			content := "  " + nameText
+			padding := menuInnerWidth - lipgloss.Width(content)
+			if padding < 0 {
+				padding = 0
+			}
+			row = leftBorder + content + strings.Repeat(" ", padding) + rightBorder
+		} else {
+			nameText := dimStyle.Render(truncBranch)
+			content := "    " + nameText
+			padding := menuInnerWidth - lipgloss.Width(content)
+			if padding < 0 {
+				padding = 0
+			}
+			row = leftBorder + content + strings.Repeat(" ", padding) + rightBorder
+		}
+		lines = append(lines, row)
+	}
+
+	lines = append(lines, emptyRow)
+	lines = append(lines, separator)
+
+	// Help row
+	helpText := "\u2191\u2193 navigate  \u23ce delete  Q cancel"
+	helpContent := helpStyle.Render(helpText)
+	helpPadding := menuInnerWidth - lipgloss.Width(helpContent) - 1
+	if helpPadding < 0 {
+		helpPadding = 0
+	}
+	lines = append(lines, leftBorder+" "+helpContent+strings.Repeat(" ", helpPadding)+rightBorder)
+	lines = append(lines, bottomBorder)
+
+	return m.centerBox(lines)
+}
+
+func (m BranchPickerModel) centerBox(lines []string) string {
+	box := strings.Join(lines, "\n")
+
+	// Center horizontally
+	if m.width > 0 {
+		boxWidth := menuInnerWidth + 2
+		leftPad := (m.width - boxWidth) / 2
+		if leftPad > 0 {
+			padStr := strings.Repeat(" ", leftPad)
+			padded := make([]string, len(lines))
+			for i, line := range lines {
+				padded[i] = padStr + line
+			}
+			box = strings.Join(padded, "\n")
+		}
+	}
+
+	// Center vertically
+	if m.height > 0 {
+		boxLines := strings.Count(box, "\n") + 1
+		topPad := (m.height - boxLines) / 2
+		if topPad > 0 {
+			box = strings.Repeat("\n", topPad) + box
+		}
+	}
+
+	return box
 }
 
 // Selected returns the selected branch name, or nil if cancelled.

--- a/internal/tui/branches.go
+++ b/internal/tui/branches.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type branchItem struct {
+	name string
+}
+
+func (i branchItem) Title() string       { return i.name }
+func (i branchItem) Description() string { return "" }
+func (i branchItem) FilterValue() string { return i.name }
+
+// BranchPickerModel lets the user pick a branch from a filterable list.
+type BranchPickerModel struct {
+	list     list.Model
+	selected *string
+	quitting bool
+}
+
+// NewBranchPicker creates a branch picker with the given branch names.
+func NewBranchPicker(branches []string) BranchPickerModel {
+	items := make([]list.Item, len(branches))
+	for i, b := range branches {
+		items[i] = branchItem{name: b}
+	}
+
+	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Select Branch"
+	l.Styles.Title = titleStyle
+
+	return BranchPickerModel{list: l}
+}
+
+func (m BranchPickerModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m BranchPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetWidth(msg.Width)
+		m.list.SetHeight(msg.Height - 2)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case tea.KeyEnter:
+			if item, ok := m.list.SelectedItem().(branchItem); ok {
+				name := item.name
+				m.selected = &name
+			}
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m BranchPickerModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	return m.list.View()
+}
+
+// Selected returns the selected branch name, or nil if cancelled.
+func (m BranchPickerModel) Selected() *string {
+	return m.selected
+}

--- a/internal/tui/mainmenu_render_test.go
+++ b/internal/tui/mainmenu_render_test.go
@@ -303,13 +303,16 @@ func TestMenuBox_WorktreeTreeConnectors(t *testing.T) {
 	box := m.renderMenuBox()
 	raw := stripAnsi(box)
 
-	// Non-last worktree should use ├─ connector
+	// All worktrees use ├─ connector (add-worktree follows)
 	if !strings.Contains(raw, "├─ feature/auth") {
-		t.Errorf("expected '├─ feature/auth' for non-last worktree, got:\n%s", raw)
+		t.Errorf("expected '├─ feature/auth' for worktree, got:\n%s", raw)
 	}
-	// Last worktree should use └─ connector
-	if !strings.Contains(raw, "└─ fix/bug") {
-		t.Errorf("expected '└─ fix/bug' for last worktree, got:\n%s", raw)
+	if !strings.Contains(raw, "├─ fix/bug") {
+		t.Errorf("expected '├─ fix/bug' for worktree, got:\n%s", raw)
+	}
+	// Add-worktree item uses └─ connector as last item
+	if !strings.Contains(raw, "└─ + Add worktree") {
+		t.Errorf("expected '└─ + Add worktree' as last item, got:\n%s", raw)
 	}
 }
 
@@ -330,9 +333,13 @@ func TestMenuBox_SingleWorktreeUsesEndConnector(t *testing.T) {
 	box := m.renderMenuBox()
 	raw := stripAnsi(box)
 
-	// Single worktree is also the last, should use └─
-	if !strings.Contains(raw, "└─ only-branch") {
-		t.Errorf("expected '└─ only-branch' for single worktree, got:\n%s", raw)
+	// Single worktree uses ├─ (add-worktree follows as └─)
+	if !strings.Contains(raw, "├─ only-branch") {
+		t.Errorf("expected '├─ only-branch' for single worktree, got:\n%s", raw)
+	}
+	// Add-worktree item uses └─ connector as last item
+	if !strings.Contains(raw, "└─ + Add worktree") {
+		t.Errorf("expected '└─ + Add worktree' as last item, got:\n%s", raw)
 	}
 }
 

--- a/internal/tui/terminal_selector.go
+++ b/internal/tui/terminal_selector.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jackuait/ghost-tab/internal/models"
+)
+
+type terminalItem struct {
+	terminal models.Terminal
+}
+
+func (i terminalItem) Title() string       { return i.terminal.String() }
+func (i terminalItem) Description() string { return i.terminal.Name }
+func (i terminalItem) FilterValue() string { return i.terminal.Name }
+
+// TerminalSelectorModel is a Bubbletea model for selecting a terminal emulator.
+type TerminalSelectorModel struct {
+	list      list.Model
+	terminals []models.Terminal
+	selected  *models.Terminal
+	quitting  bool
+}
+
+// NewTerminalSelector creates a new terminal selector with the given terminals.
+func NewTerminalSelector(terminals []models.Terminal) TerminalSelectorModel {
+	items := make([]list.Item, len(terminals))
+	for i, t := range terminals {
+		items[i] = terminalItem{terminal: t}
+	}
+
+	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Select Terminal"
+	l.Styles.Title = titleStyle
+
+	return TerminalSelectorModel{
+		list:      l,
+		terminals: terminals,
+	}
+}
+
+func (m TerminalSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m TerminalSelectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetWidth(msg.Width)
+		m.list.SetHeight(msg.Height - 2)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+
+		case "enter":
+			if item, ok := m.list.SelectedItem().(terminalItem); ok {
+				if item.terminal.Installed {
+					m.selected = &item.terminal
+				}
+				m.quitting = true
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m TerminalSelectorModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	return m.list.View()
+}
+
+// Selected returns the selected terminal, or nil if none was selected.
+func (m TerminalSelectorModel) Selected() *models.Terminal {
+	return m.selected
+}

--- a/lib/terminal-select-tui.sh
+++ b/lib/terminal-select-tui.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Terminal selection TUI wrapper using ghost-tab-tui
+
+# Interactive terminal selection.
+# Returns 0 if selected, 1 if cancelled.
+# Sets: _selected_terminal
+select_terminal_interactive() {
+  if ! command -v ghost-tab-tui &>/dev/null; then
+    error "ghost-tab-tui binary not found. Please reinstall."
+    return 1
+  fi
+
+  local result
+  if ! result=$(ghost-tab-tui select-terminal 2>/dev/null); then
+    return 1
+  fi
+
+  local selected
+  if ! selected=$(echo "$result" | jq -r '.selected' 2>/dev/null); then
+    error "Failed to parse terminal selection response"
+    return 1
+  fi
+
+  if [[ -z "$selected" || "$selected" == "null" || "$selected" != "true" ]]; then
+    return 1
+  fi
+
+  local terminal
+  if ! terminal=$(echo "$result" | jq -r '.terminal' 2>/dev/null); then
+    error "Failed to parse selected terminal"
+    return 1
+  fi
+
+  if [[ -z "$terminal" || "$terminal" == "null" ]]; then
+    error "TUI returned empty terminal selection"
+    return 1
+  fi
+
+  _selected_terminal="$terminal"
+  return 0
+}

--- a/lib/terminals/adapter.sh
+++ b/lib/terminals/adapter.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Terminal adapter loader — sources the correct adapter for a terminal.
+
+# Load the adapter for the given terminal identifier.
+# After calling this, terminal_setup_config, terminal_get_config_path, etc. are available.
+load_terminal_adapter() {
+  local terminal="$1"
+  local adapter_dir
+  adapter_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local adapter_file="$adapter_dir/${terminal}.sh"
+  if [ ! -f "$adapter_file" ]; then
+    error "Unknown terminal: $terminal"
+    return 1
+  fi
+
+  # shellcheck disable=SC1090  # Dynamic adapter loading
+  source "$adapter_file"
+}

--- a/lib/terminals/ghostty.sh
+++ b/lib/terminals/ghostty.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Ghostty terminal adapter.
+
+# Return the path to Ghostty's config file.
+terminal_get_config_path() {
+  echo "$HOME/.config/ghostty/config"
+}
+
+# Return the path where the wrapper script should be.
+terminal_get_wrapper_path() {
+  echo "$HOME/.config/ghost-tab/wrapper.sh"
+}
+
+# Install Ghostty via Homebrew cask.
+terminal_install() {
+  ensure_cask "ghostty" "Ghostty"
+}
+
+# Write or merge the wrapper command into Ghostty config.
+# Args: config_path wrapper_path
+terminal_setup_config() {
+  local config_path="$1" wrapper_path="$2"
+  local wrapper_line="command = $wrapper_path"
+
+  if [ -f "$config_path" ] && grep -q '^command[[:space:]]*=' "$config_path"; then
+    sed -i '' 's|^command[[:space:]]*=.*|'"$wrapper_line"'|' "$config_path"
+    success "Replaced existing command line in config"
+  else
+    echo "$wrapper_line" >> "$config_path"
+    success "Appended wrapper command to config"
+  fi
+}
+
+# Remove ghost-tab command line from Ghostty config.
+terminal_cleanup_config() {
+  local config_path="$1"
+  if [ -f "$config_path" ]; then
+    sed -i '' '/^command[[:space:]]*=/d' "$config_path"
+  fi
+}

--- a/lib/terminals/iterm2.sh
+++ b/lib/terminals/iterm2.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# iTerm2 terminal adapter using PlistBuddy.
+
+# Return the path to iTerm2's preferences plist.
+terminal_get_config_path() {
+  echo "$HOME/Library/Preferences/com.googlecode.iterm2.plist"
+}
+
+# Return the path where the wrapper script should be.
+terminal_get_wrapper_path() {
+  echo "$HOME/.config/ghost-tab/wrapper.sh"
+}
+
+# Install iTerm2 via Homebrew cask.
+terminal_install() {
+  ensure_cask "iterm2" "iTerm"
+}
+
+# Create a "Ghost Tab" profile in iTerm2 that runs the wrapper.
+# Args: plist_path wrapper_path
+terminal_setup_config() {
+  local plist_path="$1" wrapper_path="$2"
+
+  local pb
+  pb="$(command -v PlistBuddy 2>/dev/null || echo "/usr/libexec/PlistBuddy")"
+
+  "$pb" -c "Add ':New Bookmarks:999:Name' string 'Ghost Tab'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Set ':New Bookmarks:999:Name' 'Ghost Tab'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Add ':New Bookmarks:999:Custom Command' string 'Yes'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Set ':New Bookmarks:999:Custom Command' 'Yes'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Add ':New Bookmarks:999:Command' string '$wrapper_path'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Set ':New Bookmarks:999:Command' '$wrapper_path'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Add ':New Bookmarks:999:Guid' string 'ghost-tab-profile'" "$plist_path" 2>/dev/null || true
+  "$pb" -c "Set ':New Bookmarks:999:Guid' 'ghost-tab-profile'" "$plist_path" 2>/dev/null || true
+
+  success "Created Ghost Tab profile in iTerm2"
+  info "Set 'Ghost Tab' as your default profile in iTerm2 Preferences → Profiles"
+}
+
+# Remove the Ghost Tab profile from iTerm2.
+terminal_cleanup_config() {
+  local plist_path="$1"
+
+  local pb
+  pb="$(command -v PlistBuddy 2>/dev/null || echo "/usr/libexec/PlistBuddy")"
+
+  "$pb" -c "Delete ':New Bookmarks:999'" "$plist_path" 2>/dev/null || true
+  success "Removed Ghost Tab profile from iTerm2"
+}

--- a/lib/terminals/kitty.sh
+++ b/lib/terminals/kitty.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# kitty terminal adapter.
+
+# Return the path to kitty's config file.
+terminal_get_config_path() {
+  echo "$HOME/.config/kitty/kitty.conf"
+}
+
+# Return the path where the wrapper script should be.
+terminal_get_wrapper_path() {
+  echo "$HOME/.config/ghost-tab/wrapper.sh"
+}
+
+# Install kitty via Homebrew cask.
+terminal_install() {
+  ensure_cask "kitty" "kitty"
+}
+
+# Write or merge the wrapper command into kitty config.
+# Args: config_path wrapper_path
+terminal_setup_config() {
+  local config_path="$1" wrapper_path="$2"
+  local shell_line="shell $wrapper_path"
+
+  if [ -f "$config_path" ] && grep -q '^shell[[:space:]]' "$config_path"; then
+    sed -i '' 's|^shell[[:space:]].*|'"$shell_line"'|' "$config_path"
+    success "Replaced existing shell line in config"
+  else
+    echo "$shell_line" >> "$config_path"
+    success "Appended wrapper command to config"
+  fi
+}
+
+# Remove ghost-tab shell line from kitty config.
+terminal_cleanup_config() {
+  local config_path="$1"
+  if [ -f "$config_path" ]; then
+    sed -i '' '/^shell[[:space:]]/d' "$config_path"
+  fi
+}

--- a/lib/terminals/registry.sh
+++ b/lib/terminals/registry.sh
@@ -35,3 +35,18 @@ save_terminal_preference() {
   mkdir -p "$(dirname "$pref_file")"
   echo "$terminal" > "$pref_file"
 }
+
+# Detect if user has a legacy Ghostty-only installation.
+# Prints "ghostty" if detected, empty otherwise.
+detect_legacy_ghostty_setup() {
+  local old_wrapper="$HOME/.config/ghostty/claude-wrapper.sh"
+  local pref_file="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/terminal"
+
+  if [ -f "$old_wrapper" ] || [ -L "$old_wrapper" ]; then
+    if [ ! -f "$pref_file" ]; then
+      echo "ghostty"
+      return 0
+    fi
+  fi
+  return 1
+}

--- a/lib/terminals/registry.sh
+++ b/lib/terminals/registry.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Terminal registry — lists supported terminals and manages preference.
+
+# Print supported terminal identifiers, one per line.
+get_supported_terminals() {
+  echo "ghostty"
+  echo "iterm2"
+  echo "wezterm"
+  echo "kitty"
+}
+
+# Return the human-readable display name for a terminal identifier.
+get_terminal_display_name() {
+  local terminal="$1"
+  case "$terminal" in
+    ghostty) echo "Ghostty" ;;
+    iterm2)  echo "iTerm2" ;;
+    wezterm) echo "WezTerm" ;;
+    kitty)   echo "kitty" ;;
+    *)       echo "$terminal" ;;
+  esac
+}
+
+# Read saved terminal preference from file. Prints the terminal name or empty.
+load_terminal_preference() {
+  local pref_file="$1"
+  if [ -f "$pref_file" ]; then
+    tr -d '[:space:]' < "$pref_file"
+  fi
+}
+
+# Save terminal preference to file.
+save_terminal_preference() {
+  local terminal="$1" pref_file="$2"
+  mkdir -p "$(dirname "$pref_file")"
+  echo "$terminal" > "$pref_file"
+}

--- a/lib/terminals/wezterm.sh
+++ b/lib/terminals/wezterm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# WezTerm terminal adapter.
+
+# Return the path to WezTerm's config file.
+terminal_get_config_path() {
+  echo "$HOME/.wezterm.lua"
+}
+
+# Return the path where the wrapper script should be.
+terminal_get_wrapper_path() {
+  echo "$HOME/.config/ghost-tab/wrapper.sh"
+}
+
+# Install WezTerm via Homebrew cask.
+terminal_install() {
+  ensure_cask "wezterm" "WezTerm"
+}
+
+# Write or merge the wrapper command into WezTerm Lua config.
+# Args: config_path wrapper_path
+terminal_setup_config() {
+  local config_path="$1" wrapper_path="$2"
+
+  if [ -f "$config_path" ] && grep -q 'default_prog' "$config_path"; then
+    # Replace existing default_prog line
+    sed -i '' "s|config\.default_prog[[:space:]]*=.*|config.default_prog = { '$wrapper_path' }|" "$config_path"
+    success "Replaced existing default_prog in WezTerm config"
+  elif [ -f "$config_path" ]; then
+    # Insert before 'return config'
+    sed -i '' "s|return config|config.default_prog = { '$wrapper_path' }\nreturn config|" "$config_path"
+    success "Added default_prog to WezTerm config"
+  else
+    # Create minimal config
+    cat > "$config_path" << EOF
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+config.default_prog = { '$wrapper_path' }
+return config
+EOF
+    success "Created WezTerm config with wrapper"
+  fi
+}
+
+# Remove ghost-tab default_prog from WezTerm config.
+terminal_cleanup_config() {
+  local config_path="$1"
+  if [ -f "$config_path" ]; then
+    sed -i '' '/default_prog/d' "$config_path"
+  fi
+}

--- a/terminals/ghostty/config
+++ b/terminals/ghostty/config
@@ -2,4 +2,4 @@ keybind = cmd+shift+left=previous_tab
 keybind = cmd+shift+right=next_tab
 keybind = cmd+t=new_tab
 macos-option-as-alt = left
-command = ~/.config/ghostty/claude-wrapper.sh
+command = ~/.config/ghost-tab/wrapper.sh

--- a/terminals/ghostty/config
+++ b/terminals/ghostty/config
@@ -1,0 +1,5 @@
+keybind = cmd+shift+left=previous_tab
+keybind = cmd+shift+right=next_tab
+keybind = cmd+t=new_tab
+macos-option-as-alt = left
+command = ~/.config/ghostty/claude-wrapper.sh

--- a/terminals/kitty/config
+++ b/terminals/kitty/config
@@ -1,0 +1,1 @@
+shell ~/.config/ghost-tab/wrapper.sh

--- a/terminals/wezterm/config.lua
+++ b/terminals/wezterm/config.lua
@@ -1,0 +1,4 @@
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+config.default_prog = { '~/.config/ghost-tab/wrapper.sh' }
+return config

--- a/test/bash/terminal_adapter_test.go
+++ b/test/bash/terminal_adapter_test.go
@@ -25,6 +25,30 @@ func TestLoadTerminalAdapter_sources_ghostty_adapter(t *testing.T) {
 	assertContains(t, out, "loaded")
 }
 
+func TestLoadTerminalAdapter_sources_kitty_adapter(t *testing.T) {
+	snippet := terminalAdapterSnippet(t,
+		`load_terminal_adapter "kitty" && type terminal_get_config_path &>/dev/null && echo "loaded"`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "loaded")
+}
+
+func TestLoadTerminalAdapter_sources_wezterm_adapter(t *testing.T) {
+	snippet := terminalAdapterSnippet(t,
+		`load_terminal_adapter "wezterm" && type terminal_get_config_path &>/dev/null && echo "loaded"`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "loaded")
+}
+
+func TestLoadTerminalAdapter_sources_iterm2_adapter(t *testing.T) {
+	snippet := terminalAdapterSnippet(t,
+		`load_terminal_adapter "iterm2" && type terminal_get_config_path &>/dev/null && echo "loaded"`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "loaded")
+}
+
 func TestLoadTerminalAdapter_fails_for_unknown(t *testing.T) {
 	snippet := terminalAdapterSnippet(t,
 		`load_terminal_adapter "unknown_terminal"`)

--- a/test/bash/terminal_adapter_test.go
+++ b/test/bash/terminal_adapter_test.go
@@ -1,0 +1,35 @@
+package bash_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func terminalAdapterSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	installPath := filepath.Join(root, "lib", "install.sh")
+	registryPath := filepath.Join(root, "lib", "terminals", "registry.sh")
+	adapterPath := filepath.Join(root, "lib", "terminals", "adapter.sh")
+	return fmt.Sprintf("source %q && source %q && source %q && source %q && %s",
+		tuiPath, installPath, registryPath, adapterPath, body)
+}
+
+func TestLoadTerminalAdapter_sources_ghostty_adapter(t *testing.T) {
+	snippet := terminalAdapterSnippet(t,
+		`load_terminal_adapter "ghostty" && type terminal_get_config_path &>/dev/null && echo "loaded"`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "loaded")
+}
+
+func TestLoadTerminalAdapter_fails_for_unknown(t *testing.T) {
+	snippet := terminalAdapterSnippet(t,
+		`load_terminal_adapter "unknown_terminal"`)
+	_, code := runBashSnippet(t, snippet, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit for unknown terminal")
+	}
+}

--- a/test/bash/terminal_ghostty_test.go
+++ b/test/bash/terminal_ghostty_test.go
@@ -1,0 +1,122 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func ghosttyAdapterSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	installPath := filepath.Join(root, "lib", "install.sh")
+	adapterPath := filepath.Join(root, "lib", "terminals", "ghostty.sh")
+	return fmt.Sprintf("source %q && source %q && source %q && %s",
+		tuiPath, installPath, adapterPath, body)
+}
+
+func TestGhosttyAdapter_get_config_path(t *testing.T) {
+	snippet := ghosttyAdapterSnippet(t, `terminal_get_config_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/.config/ghostty/config"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestGhosttyAdapter_get_wrapper_path(t *testing.T) {
+	snippet := ghosttyAdapterSnippet(t, `terminal_get_wrapper_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/.config/ghost-tab/wrapper.sh"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestGhosttyAdapter_setup_config_creates_new(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := ghosttyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "Appended")
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	assertContains(t, string(data), "command = "+wrapperPath)
+}
+
+func TestGhosttyAdapter_setup_config_replaces_existing(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := writeTempFile(t, tmpDir, "config", "command = /old/path\n")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := ghosttyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "Replaced")
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := strings.TrimSpace(string(data))
+	expected := "command = " + wrapperPath
+	if content != expected {
+		t.Errorf("got %q, want %q", content, expected)
+	}
+}
+
+func TestGhosttyAdapter_setup_config_preserves_other_settings(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := writeTempFile(t, tmpDir, "config", "font-size = 14\ntheme = dark\n")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := ghosttyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "font-size = 14")
+	assertContains(t, content, "theme = dark")
+	assertContains(t, content, "command = "+wrapperPath)
+}
+
+func TestGhosttyAdapter_cleanup_config_removes_command_line(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := writeTempFile(t, tmpDir, "config", "font-size = 14\ncommand = /some/path\ntheme = dark\n")
+
+	snippet := ghosttyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_cleanup_config %q`, configFile))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "font-size = 14")
+	assertContains(t, content, "theme = dark")
+	assertNotContains(t, content, "command =")
+}

--- a/test/bash/terminal_iterm2_test.go
+++ b/test/bash/terminal_iterm2_test.go
@@ -1,0 +1,76 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func iterm2AdapterSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	installPath := filepath.Join(root, "lib", "install.sh")
+	adapterPath := filepath.Join(root, "lib", "terminals", "iterm2.sh")
+	return fmt.Sprintf("source %q && source %q && source %q && %s",
+		tuiPath, installPath, adapterPath, body)
+}
+
+func TestIterm2Adapter_get_config_path(t *testing.T) {
+	snippet := iterm2AdapterSnippet(t, `terminal_get_config_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/Library/Preferences/com.googlecode.iterm2.plist"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestIterm2Adapter_get_wrapper_path(t *testing.T) {
+	snippet := iterm2AdapterSnippet(t, `terminal_get_wrapper_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/.config/ghost-tab/wrapper.sh"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestIterm2Adapter_setup_config_calls_plistbuddy(t *testing.T) {
+	tmpDir := t.TempDir()
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	binDir := mockCommand(t, tmpDir, "PlistBuddy", `echo "PlistBuddy called: $*"`)
+	env := buildEnv(t, []string{binDir})
+
+	plistFile := filepath.Join(tmpDir, "com.googlecode.iterm2.plist")
+	writeTempFile(t, tmpDir, "com.googlecode.iterm2.plist", "")
+
+	snippet := iterm2AdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, plistFile, wrapperPath))
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "PlistBuddy called")
+}
+
+func TestIterm2Adapter_cleanup_config_calls_plistbuddy_delete(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	binDir := mockCommand(t, tmpDir, "PlistBuddy", `echo "PlistBuddy called: $*"`)
+	env := buildEnv(t, []string{binDir})
+
+	plistFile := filepath.Join(tmpDir, "com.googlecode.iterm2.plist")
+	writeTempFile(t, tmpDir, "com.googlecode.iterm2.plist", "")
+
+	snippet := iterm2AdapterSnippet(t,
+		fmt.Sprintf(`terminal_cleanup_config %q`, plistFile))
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "Delete")
+}

--- a/test/bash/terminal_kitty_test.go
+++ b/test/bash/terminal_kitty_test.go
@@ -1,0 +1,88 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func kittyAdapterSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	installPath := filepath.Join(root, "lib", "install.sh")
+	adapterPath := filepath.Join(root, "lib", "terminals", "kitty.sh")
+	return fmt.Sprintf("source %q && source %q && source %q && %s",
+		tuiPath, installPath, adapterPath, body)
+}
+
+func TestKittyAdapter_get_config_path(t *testing.T) {
+	snippet := kittyAdapterSnippet(t, `terminal_get_config_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/.config/kitty/kitty.conf"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestKittyAdapter_setup_config_creates_new(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "kitty.conf")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := kittyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "Appended")
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	assertContains(t, string(data), "shell "+wrapperPath)
+}
+
+func TestKittyAdapter_setup_config_replaces_existing_shell(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := writeTempFile(t, tmpDir, "kitty.conf", "shell /old/path\nfont_size 14\n")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := kittyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "Replaced")
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "shell "+wrapperPath)
+	assertContains(t, content, "font_size 14")
+	assertNotContains(t, content, "/old/path")
+}
+
+func TestKittyAdapter_cleanup_config_removes_shell_line(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := writeTempFile(t, tmpDir, "kitty.conf", "font_size 14\nshell /some/path\ntheme dark\n")
+
+	snippet := kittyAdapterSnippet(t,
+		fmt.Sprintf(`terminal_cleanup_config %q`, configFile))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "font_size 14")
+	assertNotContains(t, content, "shell ")
+}

--- a/test/bash/terminal_registry_test.go
+++ b/test/bash/terminal_registry_test.go
@@ -1,0 +1,94 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func terminalRegistrySnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	registryPath := filepath.Join(root, "lib", "terminals", "registry.sh")
+	return fmt.Sprintf("source %q && source %q && %s", tuiPath, registryPath, body)
+}
+
+func TestGetSupportedTerminals_lists_four_terminals(t *testing.T) {
+	snippet := terminalRegistrySnippet(t, `get_supported_terminals`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	for _, name := range []string{"ghostty", "iterm2", "wezterm", "kitty"} {
+		assertContains(t, out, name)
+	}
+}
+
+func TestGetTerminalDisplayName_returns_display_names(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		display string
+	}{
+		{"ghostty", "ghostty", "Ghostty"},
+		{"iterm2", "iterm2", "iTerm2"},
+		{"wezterm", "wezterm", "WezTerm"},
+		{"kitty", "kitty", "kitty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snippet := terminalRegistrySnippet(t,
+				fmt.Sprintf(`get_terminal_display_name %q`, tt.input))
+			out, code := runBashSnippet(t, snippet, nil)
+			assertExitCode(t, code, 0)
+			got := strings.TrimSpace(out)
+			if got != tt.display {
+				t.Errorf("got %q, want %q", got, tt.display)
+			}
+		})
+	}
+}
+
+func TestLoadTerminalPreference_reads_saved_file(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeTempFile(t, tmpDir, "terminal", "wezterm\n")
+	snippet := terminalRegistrySnippet(t,
+		fmt.Sprintf(`load_terminal_preference %q`, filepath.Join(tmpDir, "terminal")))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	if got != "wezterm" {
+		t.Errorf("got %q, want %q", got, "wezterm")
+	}
+}
+
+func TestLoadTerminalPreference_returns_empty_when_missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	snippet := terminalRegistrySnippet(t,
+		fmt.Sprintf(`load_terminal_preference %q`, filepath.Join(tmpDir, "nonexistent")))
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestSaveTerminalPreference_writes_file(t *testing.T) {
+	tmpDir := t.TempDir()
+	prefFile := filepath.Join(tmpDir, "terminal")
+	snippet := terminalRegistrySnippet(t,
+		fmt.Sprintf(`save_terminal_preference %q %q`, "kitty", prefFile))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(prefFile)
+	if err != nil {
+		t.Fatalf("failed to read pref file: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got != "kitty" {
+		t.Errorf("got %q, want %q", got, "kitty")
+	}
+}

--- a/test/bash/terminal_select_tui_test.go
+++ b/test/bash/terminal_select_tui_test.go
@@ -1,0 +1,52 @@
+package bash_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func terminalSelectTuiSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	selectPath := filepath.Join(root, "lib", "terminal-select-tui.sh")
+	return fmt.Sprintf("source %q && source %q && %s", tuiPath, selectPath, body)
+}
+
+func TestSelectTerminalInteractive_parses_selected_json(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := mockCommand(t, tmpDir, "ghost-tab-tui", `echo '{"terminal":"wezterm","selected":true}'`)
+	env := buildEnv(t, []string{binDir})
+
+	snippet := terminalSelectTuiSnippet(t,
+		`select_terminal_interactive && echo "SELECTED=$_selected_terminal"`)
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "SELECTED=wezterm")
+}
+
+func TestSelectTerminalInteractive_returns_1_on_cancel(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := mockCommand(t, tmpDir, "ghost-tab-tui", `echo '{"selected":false}'`)
+	env := buildEnv(t, []string{binDir})
+
+	snippet := terminalSelectTuiSnippet(t,
+		`select_terminal_interactive`)
+	_, code := runBashSnippet(t, snippet, env)
+	if code == 0 {
+		t.Error("expected non-zero exit on cancel")
+	}
+}
+
+func TestSelectTerminalInteractive_returns_1_when_binary_missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	env := buildEnv(t, []string{filepath.Join(tmpDir, "empty")})
+
+	snippet := terminalSelectTuiSnippet(t,
+		`select_terminal_interactive`)
+	_, code := runBashSnippet(t, snippet, env)
+	if code == 0 {
+		t.Error("expected non-zero exit when binary missing")
+	}
+}

--- a/test/bash/terminal_wezterm_test.go
+++ b/test/bash/terminal_wezterm_test.go
@@ -1,0 +1,112 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func weztermAdapterSnippet(t *testing.T, body string) string {
+	t.Helper()
+	root := projectRoot(t)
+	tuiPath := filepath.Join(root, "lib", "tui.sh")
+	installPath := filepath.Join(root, "lib", "install.sh")
+	adapterPath := filepath.Join(root, "lib", "terminals", "wezterm.sh")
+	return fmt.Sprintf("source %q && source %q && source %q && %s",
+		tuiPath, installPath, adapterPath, body)
+}
+
+func TestWeztermAdapter_get_config_path(t *testing.T) {
+	snippet := weztermAdapterSnippet(t, `terminal_get_config_path`)
+	out, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+	got := strings.TrimSpace(out)
+	home := os.Getenv("HOME")
+	expected := home + "/.wezterm.lua"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestWeztermAdapter_setup_config_creates_new(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".wezterm.lua")
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := weztermAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "default_prog")
+	assertContains(t, content, wrapperPath)
+}
+
+func TestWeztermAdapter_setup_config_replaces_existing(t *testing.T) {
+	tmpDir := t.TempDir()
+	existing := "local wezterm = require 'wezterm'\nlocal config = wezterm.config_builder()\nconfig.default_prog = { '/old/path' }\nreturn config\n"
+	configFile := writeTempFile(t, tmpDir, ".wezterm.lua", existing)
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := weztermAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, wrapperPath)
+	assertNotContains(t, content, "/old/path")
+	assertContains(t, content, "wezterm.config_builder()")
+}
+
+func TestWeztermAdapter_setup_config_inserts_before_return(t *testing.T) {
+	tmpDir := t.TempDir()
+	existing := "local wezterm = require 'wezterm'\nlocal config = wezterm.config_builder()\nconfig.font_size = 14\nreturn config\n"
+	configFile := writeTempFile(t, tmpDir, ".wezterm.lua", existing)
+	wrapperPath := filepath.Join(tmpDir, "wrapper.sh")
+
+	snippet := weztermAdapterSnippet(t,
+		fmt.Sprintf(`terminal_setup_config %q %q`, configFile, wrapperPath))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertContains(t, content, "default_prog")
+	assertContains(t, content, wrapperPath)
+	assertContains(t, content, "font_size = 14")
+	assertContains(t, content, "return config")
+}
+
+func TestWeztermAdapter_cleanup_config_removes_default_prog(t *testing.T) {
+	tmpDir := t.TempDir()
+	existing := "local wezterm = require 'wezterm'\nlocal config = wezterm.config_builder()\nconfig.default_prog = { '/some/path' }\nconfig.font_size = 14\nreturn config\n"
+	configFile := writeTempFile(t, tmpDir, ".wezterm.lua", existing)
+
+	snippet := weztermAdapterSnippet(t,
+		fmt.Sprintf(`terminal_cleanup_config %q`, configFile))
+	_, code := runBashSnippet(t, snippet, nil)
+	assertExitCode(t, code, 0)
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	content := string(data)
+	assertNotContains(t, content, "default_prog")
+	assertContains(t, content, "font_size = 14")
+}

--- a/test/internal/models/terminal_test.go
+++ b/test/internal/models/terminal_test.go
@@ -1,0 +1,65 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/jackuait/ghost-tab/internal/models"
+)
+
+func TestSupportedTerminals_returns_four_terminals(t *testing.T) {
+	terminals := models.SupportedTerminals()
+	if len(terminals) != 4 {
+		t.Errorf("expected 4 terminals, got %d", len(terminals))
+	}
+}
+
+func TestSupportedTerminals_contains_ghostty(t *testing.T) {
+	terminals := models.SupportedTerminals()
+	found := false
+	for _, term := range terminals {
+		if term.Name == "ghostty" {
+			found = true
+			if term.DisplayName != "Ghostty" {
+				t.Errorf("expected DisplayName 'Ghostty', got %q", term.DisplayName)
+			}
+			if term.CaskName != "ghostty" {
+				t.Errorf("expected CaskName 'ghostty', got %q", term.CaskName)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find ghostty in supported terminals")
+	}
+}
+
+func TestTerminal_String_shows_installed_status(t *testing.T) {
+	term := models.Terminal{
+		Name:        "ghostty",
+		DisplayName: "Ghostty",
+		Installed:   true,
+	}
+	got := term.String()
+	if got != "Ghostty ✓" {
+		t.Errorf("expected 'Ghostty ✓', got %q", got)
+	}
+}
+
+func TestTerminal_String_shows_not_installed(t *testing.T) {
+	term := models.Terminal{
+		Name:        "ghostty",
+		DisplayName: "Ghostty",
+		Installed:   false,
+	}
+	got := term.String()
+	if got != "Ghostty (not installed)" {
+		t.Errorf("expected 'Ghostty (not installed)', got %q", got)
+	}
+}
+
+func TestDetectTerminals_marks_installation_status(t *testing.T) {
+	terminals := models.DetectTerminals()
+	if len(terminals) == 0 {
+		t.Error("expected at least one terminal")
+	}
+}

--- a/test/internal/models/worktree_test.go
+++ b/test/internal/models/worktree_test.go
@@ -196,3 +196,42 @@ func TestFilterAvailableBranches(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMainBranch(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "main branch",
+			output: "worktree /Users/jack/ghost-tab\nHEAD abc123\nbranch refs/heads/main\n\n",
+			want:   "main",
+		},
+		{
+			name:   "master branch",
+			output: "worktree /Users/jack/project\nHEAD abc123\nbranch refs/heads/master\n\n",
+			want:   "master",
+		},
+		{
+			name: "with additional worktrees returns first",
+			output: "worktree /Users/jack/ghost-tab\nHEAD abc\nbranch refs/heads/main\n\n" +
+				"worktree /wt/feature\nHEAD def\nbranch refs/heads/feature\n\n",
+			want: "main",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := models.ParseMainBranch(tt.output)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/internal/models/worktree_test.go
+++ b/test/internal/models/worktree_test.go
@@ -180,6 +180,27 @@ func TestFilterAvailableBranches(t *testing.T) {
 			mainBranch: "",
 			want:       []string{"feature/a", "feature/b"},
 		},
+		{
+			name:       "filters out master even when main branch is different",
+			branches:   []string{"develop", "master", "feature/x"},
+			worktrees:  nil,
+			mainBranch: "develop",
+			want:       []string{"feature/x"},
+		},
+		{
+			name:       "filters out main even when main branch is different",
+			branches:   []string{"develop", "main", "feature/x"},
+			worktrees:  nil,
+			mainBranch: "develop",
+			want:       []string{"feature/x"},
+		},
+		{
+			name:       "filters out origin/main and origin/master",
+			branches:   []string{"origin/main", "origin/master", "origin/feature/y"},
+			worktrees:  nil,
+			mainBranch: "",
+			want:       []string{"origin/feature/y"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/internal/models/worktree_test.go
+++ b/test/internal/models/worktree_test.go
@@ -93,3 +93,51 @@ func TestLoadProjectsWithWorktrees_NonGitDir(t *testing.T) {
 		t.Errorf("expected 0 worktrees for non-git dir, got %d", len(projects[0].Worktrees))
 	}
 }
+
+func TestParseBranchList(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []string
+	}{
+		{
+			name:   "local and remote branches",
+			output: "  main\n  feature/auth\n  origin/main\n  origin/feature/auth\n  origin/fix/cleanup\n",
+			want:   []string{"main", "feature/auth", "origin/fix/cleanup"},
+		},
+		{
+			name:   "deduplicates local+remote same branch",
+			output: "  main\n  origin/main\n",
+			want:   []string{"main"},
+		},
+		{
+			name:   "strips HEAD pointer",
+			output: "  main\n  origin/HEAD\n  origin/main\n",
+			want:   []string{"main"},
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   nil,
+		},
+		{
+			name:   "remote-only branch kept with origin/ prefix",
+			output: "  origin/feature/new\n",
+			want:   []string{"origin/feature/new"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := models.ParseBranchList(tt.output)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d branches %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("branch[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/test/internal/models/worktree_test.go
+++ b/test/internal/models/worktree_test.go
@@ -141,3 +141,58 @@ func TestParseBranchList(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterAvailableBranches(t *testing.T) {
+	tests := []struct {
+		name       string
+		branches   []string
+		worktrees  []models.Worktree
+		mainBranch string
+		want       []string
+	}{
+		{
+			name:     "filters out branches with existing worktrees",
+			branches: []string{"main", "feature/auth", "fix/cleanup", "develop"},
+			worktrees: []models.Worktree{
+				{Path: "/wt/auth", Branch: "feature/auth"},
+			},
+			mainBranch: "main",
+			want:       []string{"fix/cleanup", "develop"},
+		},
+		{
+			name:       "filters out main branch",
+			branches:   []string{"main", "feature/new"},
+			worktrees:  nil,
+			mainBranch: "main",
+			want:       []string{"feature/new"},
+		},
+		{
+			name:       "all branches taken returns nil",
+			branches:   []string{"main"},
+			worktrees:  nil,
+			mainBranch: "main",
+			want:       nil,
+		},
+		{
+			name:       "no worktrees no main returns all",
+			branches:   []string{"feature/a", "feature/b"},
+			worktrees:  nil,
+			mainBranch: "",
+			want:       []string{"feature/a", "feature/b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := models.FilterAvailableBranches(tt.branches, tt.worktrees, tt.mainBranch)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d branches %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("branch[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/test/internal/tui/branches_test.go
+++ b/test/internal/tui/branches_test.go
@@ -1,0 +1,78 @@
+package tui_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jackuait/ghost-tab/internal/tui"
+)
+
+func TestBranchPicker_SelectBranch(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches)
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(tui.BranchPickerModel)
+
+	selected := m.Selected()
+	if selected == nil {
+		t.Fatal("expected a selected branch")
+	}
+	if *selected != "feature/auth" {
+		t.Errorf("got %q, want %q", *selected, "feature/auth")
+	}
+}
+
+func TestBranchPicker_Cancel(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup"}
+	m := tui.NewBranchPicker(branches)
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(tui.BranchPickerModel)
+
+	if m.Selected() != nil {
+		t.Error("expected nil selection on cancel")
+	}
+}
+
+func TestBranchPicker_EmptyList(t *testing.T) {
+	m := tui.NewBranchPicker(nil)
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(tui.BranchPickerModel)
+
+	if m.Selected() != nil {
+		t.Error("expected nil selection on empty list")
+	}
+}
+
+func TestBranchPicker_NavigateAndSelect(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches)
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(tui.BranchPickerModel)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(tui.BranchPickerModel)
+
+	selected := m.Selected()
+	if selected == nil {
+		t.Fatal("expected a selected branch")
+	}
+	if *selected != "fix/cleanup" {
+		t.Errorf("got %q, want %q", *selected, "fix/cleanup")
+	}
+}

--- a/test/internal/tui/branches_test.go
+++ b/test/internal/tui/branches_test.go
@@ -1,15 +1,20 @@
 package tui_test
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jackuait/ghost-tab/internal/tui"
 )
 
+func testTheme() tui.AIToolTheme {
+	return tui.ThemeForTool("claude")
+}
+
 func TestBranchPicker_SelectBranch(t *testing.T) {
 	branches := []string{"feature/auth", "fix/cleanup", "develop"}
-	m := tui.NewBranchPicker(branches)
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
 
 	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = sized.(tui.BranchPickerModel)
@@ -28,7 +33,7 @@ func TestBranchPicker_SelectBranch(t *testing.T) {
 
 func TestBranchPicker_Cancel(t *testing.T) {
 	branches := []string{"feature/auth", "fix/cleanup"}
-	m := tui.NewBranchPicker(branches)
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
 
 	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = sized.(tui.BranchPickerModel)
@@ -42,7 +47,7 @@ func TestBranchPicker_Cancel(t *testing.T) {
 }
 
 func TestBranchPicker_EmptyList(t *testing.T) {
-	m := tui.NewBranchPicker(nil)
+	m := tui.NewBranchPicker(nil, testTheme(), "/tmp/project")
 
 	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = sized.(tui.BranchPickerModel)
@@ -57,7 +62,7 @@ func TestBranchPicker_EmptyList(t *testing.T) {
 
 func TestBranchPicker_NavigateAndSelect(t *testing.T) {
 	branches := []string{"feature/auth", "fix/cleanup", "develop"}
-	m := tui.NewBranchPicker(branches)
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
 
 	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = sized.(tui.BranchPickerModel)
@@ -74,5 +79,285 @@ func TestBranchPicker_NavigateAndSelect(t *testing.T) {
 	}
 	if *selected != "fix/cleanup" {
 		t.Errorf("got %q, want %q", *selected, "fix/cleanup")
+	}
+}
+
+func TestBranchPicker_FilterAndSelect(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press '/' to enter filter mode, then type "dev"
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(tui.BranchPickerModel)
+	for _, r := range "dev" {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(tui.BranchPickerModel)
+	}
+
+	// Enter selects the only matching item
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(tui.BranchPickerModel)
+
+	selected := m.Selected()
+	if selected == nil {
+		t.Fatal("expected a selected branch")
+	}
+	if *selected != "develop" {
+		t.Errorf("got %q, want %q", *selected, "develop")
+	}
+}
+
+func TestBranchPicker_EscClearsFilter(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press '/' then type "dev" to filter
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(tui.BranchPickerModel)
+	for _, r := range "dev" {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(tui.BranchPickerModel)
+	}
+
+	// First Esc clears filter and exits filter mode (not quit)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(tui.BranchPickerModel)
+
+	// Should not have quit — view should still render
+	view := m.View()
+	if view == "" {
+		t.Error("expected non-empty view after clearing filter")
+	}
+
+	// All branches should be visible again
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected all branches visible after clearing filter")
+	}
+}
+
+func TestBranchPicker_ViewHasBoxBorders(t *testing.T) {
+	branches := []string{"feature/auth", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	view := m.View()
+	if !strings.Contains(view, "\u250c") { // ┌
+		t.Error("expected top-left border character")
+	}
+	if !strings.Contains(view, "\u2518") { // ┘
+		t.Error("expected bottom-right border character")
+	}
+	if !strings.Contains(view, "Select Branch") {
+		t.Error("expected title in view")
+	}
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected branch name in view")
+	}
+}
+
+func TestBranchPicker_DeleteMode(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press 'd' to enter delete mode
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(tui.BranchPickerModel)
+
+	view := m.View()
+	// Title should show "· Delete" suffix like project delete mode
+	if !strings.Contains(view, "Delete") {
+		t.Error("expected title to contain 'Delete'")
+	}
+	// Help bar should show delete-mode controls
+	if !strings.Contains(view, "delete") {
+		t.Error("expected help bar with delete action")
+	}
+	if !strings.Contains(view, "cancel") {
+		t.Error("expected help bar with cancel option")
+	}
+	// Branches should still be listed
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected branches visible in delete mode")
+	}
+}
+
+func TestBranchPicker_DeleteCancel(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press 'd' then Esc to cancel
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(tui.BranchPickerModel)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(tui.BranchPickerModel)
+
+	// Should be back to normal view — title should not show "Delete"
+	view := m.View()
+	if strings.Contains(view, "\u00b7 Delete") {
+		t.Error("expected delete mode to be dismissed after Esc")
+	}
+	// All branches should still be present
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected all branches still present after cancel")
+	}
+}
+
+func TestBranchPicker_DeleteCancelQ(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press 'd' then 'q' to cancel
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(tui.BranchPickerModel)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(tui.BranchPickerModel)
+
+	// Should be back to normal view
+	view := m.View()
+	if strings.Contains(view, "\u00b7 Delete") {
+		t.Error("expected delete mode to be dismissed after 'q'")
+	}
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected all branches still present after cancel")
+	}
+}
+
+func TestBranchPicker_DeleteRemovesBranch(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Simulate receiving a successful branchDeletedMsg
+	updated, _ := m.Update(tui.BranchDeletedMsg{Branch: "feature/auth", Err: nil})
+	m = updated.(tui.BranchPickerModel)
+
+	// Feedback should show "Deleted feature/auth"
+	view := m.View()
+	if !strings.Contains(view, "Deleted") {
+		t.Error("expected success feedback message")
+	}
+	if !strings.Contains(view, "fix/cleanup") {
+		t.Error("expected remaining branches to still be visible")
+	}
+
+	// Press any key to clear feedback, then verify branch is gone
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(tui.BranchPickerModel)
+
+	view = m.View()
+	if strings.Contains(view, "feature/auth") {
+		t.Error("expected deleted branch to be removed from view")
+	}
+	if !strings.Contains(view, "fix/cleanup") {
+		t.Error("expected remaining branches to still be visible after feedback cleared")
+	}
+}
+
+func TestBranchPicker_DeleteModeScrolls(t *testing.T) {
+	// Many branches in a small terminal — delete mode must scroll
+	branches := make([]string, 30)
+	for i := range branches {
+		branches[i] = "branch-" + string(rune('a'+i%26)) + "-" + strings.Repeat("x", i)
+	}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	// Height 12 → visibleItemCount = 12-8 = 4 (delete box has 8 fixed rows)
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 12})
+	m = sized.(tui.BranchPickerModel)
+
+	// Enter delete mode
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(tui.BranchPickerModel)
+
+	view := m.View()
+	lineCount := strings.Count(view, "\n") + 1
+	// View must not exceed terminal height
+	if lineCount > 12 {
+		t.Errorf("delete mode view has %d lines, exceeds terminal height 12", lineCount)
+	}
+	// First branch should be visible
+	if !strings.Contains(view, branches[0]) {
+		t.Error("expected first branch visible")
+	}
+	// A branch far down should NOT be visible
+	if strings.Contains(view, branches[29]) {
+		t.Error("expected branch 29 to be scrolled out of view")
+	}
+}
+
+func TestBranchPicker_DeleteKeyIgnoredWhileFiltering(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Press '/' to enter filter mode, then type "d"
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(tui.BranchPickerModel)
+
+	// Now type 'd' — should add to filter, not trigger delete mode
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(tui.BranchPickerModel)
+
+	view := m.View()
+	// Should NOT show delete mode title
+	if strings.Contains(view, "\u00b7 Delete") {
+		t.Error("'d' should add to filter text, not trigger delete mode")
+	}
+}
+
+func TestBranchPicker_SlashActivatesFilterMode(t *testing.T) {
+	branches := []string{"feature/auth", "fix/cleanup", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	// Without pressing '/', typing should NOT filter
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(tui.BranchPickerModel)
+
+	view := m.View()
+	// All branches should still be visible (no filtering happened)
+	if !strings.Contains(view, "feature/auth") {
+		t.Error("expected all branches visible when not in filter mode")
+	}
+	if !strings.Contains(view, "develop") {
+		t.Error("expected all branches visible when not in filter mode")
+	}
+}
+
+func TestBranchPicker_HelpBarShowsSlash(t *testing.T) {
+	branches := []string{"feature/auth", "develop"}
+	m := tui.NewBranchPicker(branches, testTheme(), "/tmp/project")
+
+	sized, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = sized.(tui.BranchPickerModel)
+
+	view := m.View()
+	if !strings.Contains(view, "/ filter") {
+		t.Error("expected help bar to show '/ filter'")
 	}
 }

--- a/test/internal/tui/terminal_selector_test.go
+++ b/test/internal/tui/terminal_selector_test.go
@@ -1,0 +1,120 @@
+package tui_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jackuait/ghost-tab/internal/models"
+	"github.com/jackuait/ghost-tab/internal/tui"
+)
+
+func testTerminals() []models.Terminal {
+	return []models.Terminal{
+		{Name: "ghostty", DisplayName: "Ghostty", Installed: true},
+		{Name: "iterm2", DisplayName: "iTerm2", Installed: true},
+		{Name: "wezterm", DisplayName: "WezTerm", Installed: false},
+		{Name: "kitty", DisplayName: "kitty", Installed: true},
+	}
+}
+
+func TestTerminalSelector_initial_state_has_no_selection(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	if m.Selected() != nil {
+		t.Error("expected no selection initially")
+	}
+}
+
+func TestTerminalSelector_enter_selects_installed_terminal(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	result := updated.(tui.TerminalSelectorModel)
+	selected := result.Selected()
+	if selected == nil {
+		t.Fatal("expected a selection")
+	}
+	if selected.Name != "ghostty" {
+		t.Errorf("expected ghostty, got %q", selected.Name)
+	}
+}
+
+func TestTerminalSelector_enter_does_not_select_uninstalled(t *testing.T) {
+	var model tea.Model = tui.NewTerminalSelector(testTerminals())
+	// Move down to wezterm (index 2, not installed)
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	result := model.(tui.TerminalSelectorModel)
+	if result.Selected() != nil {
+		t.Error("expected no selection for uninstalled terminal")
+	}
+}
+
+func TestTerminalSelector_escape_cancels(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	result := updated.(tui.TerminalSelectorModel)
+	if result.Selected() != nil {
+		t.Error("expected no selection after escape")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestTerminalSelector_ctrl_c_cancels(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	result := updated.(tui.TerminalSelectorModel)
+	if result.Selected() != nil {
+		t.Error("expected no selection after ctrl+c")
+	}
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestTerminalSelector_init_returns_nil(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	if m.Init() != nil {
+		t.Error("Init should return nil")
+	}
+}
+
+func TestTerminalSelector_window_size_msg(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if cmd != nil {
+		t.Error("WindowSizeMsg should return nil cmd")
+	}
+	_ = updated // should not panic
+}
+
+func TestTerminalSelector_view_non_empty(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	view := updated.(tui.TerminalSelectorModel).View()
+	if view == "" {
+		t.Error("View should not be empty before quitting")
+	}
+}
+
+func TestTerminalSelector_view_empty_after_quit(t *testing.T) {
+	m := tui.NewTerminalSelector(testTerminals())
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	result := updated.(tui.TerminalSelectorModel)
+	if result.View() != "" {
+		t.Error("View should be empty after quitting")
+	}
+}
+
+func TestTerminalSelector_enter_on_only_uninstalled(t *testing.T) {
+	terminals := []models.Terminal{
+		{Name: "wezterm", DisplayName: "WezTerm", Installed: false},
+	}
+	m := tui.NewTerminalSelector(terminals)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	result := updated.(tui.TerminalSelectorModel)
+	if result.Selected() != nil {
+		t.Error("should not select uninstalled terminal")
+	}
+}

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# Show animated loading screen immediately in interactive mode (no args)
+_wrapper_dir_early="$(cd "$(dirname "$0")" && pwd)"
+if [ -z "$1" ] && [ -f "$_wrapper_dir_early/lib/loading.sh" ]; then
+  # shellcheck disable=SC1091  # Dynamic path
+  source "$_wrapper_dir_early/lib/loading.sh"
+  show_loading_screen
+fi
+
+# Self-healing: Check if ghost-tab-tui exists, rebuild if missing
+if ! command -v ghost-tab-tui &>/dev/null; then
+  # Simple inline rebuild without TUI functions (not loaded yet)
+  if command -v go &>/dev/null; then
+    printf 'Rebuilding ghost-tab-tui...\n' >&2
+    mkdir -p "$HOME/.local/bin"
+    # Determine SHARE_DIR location
+    # 1. Try wrapper script's actual location (for dev/symlink setups)
+    _wrapper_real_path="$(cd "$(dirname "$(readlink "$0" || echo "$0")")" && pwd)"
+    _candidate_share_dir="$(cd "$_wrapper_real_path/.." && pwd)"
+    if [ -f "$_candidate_share_dir/cmd/ghost-tab-tui/main.go" ]; then
+      SHARE_DIR="$_candidate_share_dir"
+    # 2. Try standard install locations
+    elif [ -f "/opt/homebrew/share/ghost-tab/cmd/ghost-tab-tui/main.go" ]; then
+      SHARE_DIR="/opt/homebrew/share/ghost-tab"
+    elif [ -f "/usr/local/share/ghost-tab/cmd/ghost-tab-tui/main.go" ]; then
+      SHARE_DIR="/usr/local/share/ghost-tab"
+    elif [ -f "$HOME/.local/share/ghost-tab/cmd/ghost-tab-tui/main.go" ]; then
+      SHARE_DIR="$HOME/.local/share/ghost-tab"
+    else
+      printf '\033[31mError:\033[0m Cannot find ghost-tab source code\n' >&2
+      printf 'Run \033[1mghost-tab\033[0m to reinstall.\n' >&2
+      printf 'Press any key to exit...\n' >&2
+      read -rsn1
+      exit 1
+    fi
+    # Build from module root with relative path to cmd
+    if (cd "$SHARE_DIR" && go build -o "$HOME/.local/bin/ghost-tab-tui" ./cmd/ghost-tab-tui) 2>/dev/null; then
+      printf 'ghost-tab-tui rebuilt successfully\n' >&2
+      export PATH="$HOME/.local/bin:$PATH"
+    else
+      printf '\033[31mError:\033[0m Failed to rebuild ghost-tab-tui\n' >&2
+      printf 'Run \033[1mghost-tab\033[0m to reinstall.\n' >&2
+      printf 'Press any key to exit...\n' >&2
+      read -rsn1
+      exit 1
+    fi
+  else
+    printf '\033[31mError:\033[0m ghost-tab-tui binary not found and Go not installed\n' >&2
+    printf 'Run \033[1mghost-tab\033[0m to reinstall.\n' >&2
+    printf 'Press any key to exit...\n' >&2
+    read -rsn1
+    exit 1
+  fi
+fi
+
+# Load shared library functions
+_WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -d "$_WRAPPER_DIR/lib" ]; then
+  printf '\033[31mError:\033[0m Ghost Tab libraries not found at %s/lib\n' "$_WRAPPER_DIR" >&2
+  printf 'Run \033[1mghost-tab\033[0m to reinstall.\n' >&2
+  printf 'Press any key to exit...\n' >&2
+  read -rsn1
+  exit 1
+fi
+
+_gt_libs=(ai-tools projects process input tui update menu-tui project-actions tmux-session settings-menu-tui settings-json notification-setup)
+for _gt_lib in "${_gt_libs[@]}"; do
+  if [ ! -f "$_WRAPPER_DIR/lib/${_gt_lib}.sh" ]; then
+    printf '\033[31mError:\033[0m Missing library %s/lib/%s.sh\n' "$_WRAPPER_DIR" "$_gt_lib" >&2
+    printf 'Run \033[1mghost-tab\033[0m to reinstall.\n' >&2
+    printf 'Press any key to exit...\n' >&2
+    read -rsn1
+    exit 1
+  fi
+  # shellcheck disable=SC1090  # Dynamic module loading
+  source "$_WRAPPER_DIR/lib/${_gt_lib}.sh"
+done
+unset _gt_libs _gt_lib
+
+TMUX_CMD="$(command -v tmux)"
+LAZYGIT_CMD="$(command -v lazygit)"
+BROOT_CMD="$(command -v broot)"
+CLAUDE_CMD="$(command -v claude)"
+CODEX_CMD="$(command -v codex)"
+COPILOT_CMD="$(command -v copilot)"
+OPENCODE_CMD="$(command -v opencode)"
+
+# AI tool preference
+AI_TOOL_PREF_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/ai-tool"
+AI_TOOLS_AVAILABLE=()
+[ -n "$CLAUDE_CMD" ] && AI_TOOLS_AVAILABLE+=("claude")
+[ -n "$CODEX_CMD" ] && AI_TOOLS_AVAILABLE+=("codex")
+[ -n "$COPILOT_CMD" ] && AI_TOOLS_AVAILABLE+=("copilot")
+[ -n "$OPENCODE_CMD" ] && AI_TOOLS_AVAILABLE+=("opencode")
+
+# Read saved preference, default to first available
+SELECTED_AI_TOOL=""
+if [ -f "$AI_TOOL_PREF_FILE" ]; then
+  SELECTED_AI_TOOL="$(cat "$AI_TOOL_PREF_FILE" 2>/dev/null | tr -d '[:space:]')"
+fi
+# Validate saved preference is still installed
+validate_ai_tool "$AI_TOOL_PREF_FILE"
+
+# Load user projects from config file if it exists
+PROJECTS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/projects"
+
+# Version update check (Homebrew only)
+# shellcheck disable=SC2034  # Used in sourced update.sh module
+UPDATE_CACHE="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/.update-check"
+_update_version=""
+
+check_for_update
+
+# Select working directory
+if [ -n "$1" ] && [ -d "$1" ]; then
+  cd "$1" || exit 1
+  shift
+elif [ -z "$1" ]; then
+  # Use TUI for project selection
+  printf '\033]0;👻 Ghost Tab\007'
+
+  # Stop loading animation before TUI takes over
+  type stop_loading_screen &>/dev/null && stop_loading_screen
+
+  while true; do
+    if select_project_interactive "$PROJECTS_FILE"; then
+      # Update AI tool if user cycled it in the menu (for all actions)
+      if [[ -n "${_selected_ai_tool:-}" ]]; then
+        SELECTED_AI_TOOL="$_selected_ai_tool"
+      fi
+      # shellcheck disable=SC2154
+      case "$_selected_project_action" in
+        select-project|open-once)
+          PROJECT_NAME="$_selected_project_name"
+          # shellcheck disable=SC2154
+          cd "$_selected_project_path" || exit 1
+          break
+          ;;
+        plain-terminal)
+          exec "$SHELL"
+          ;;
+        add-worktree)
+          # Loop back to menu — worktrees refresh on reload
+          continue
+          ;;
+        *)
+          # settings or unknown — loop back to menu
+          continue
+          ;;
+      esac
+    else
+      # User quit (ESC/Ctrl-C)
+      exit 0
+    fi
+  done
+fi
+
+PROJECT_DIR="$(pwd)"
+export PROJECT_DIR
+export PROJECT_NAME="${PROJECT_NAME:-$(basename "$PROJECT_DIR")}"
+SESSION_NAME="dev-${PROJECT_NAME}-$$"
+
+# Capture session baseline for line diff tracking
+GHOST_TAB_BASELINE_FILE="/tmp/ghost-tab-baseline-${SESSION_NAME}"
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  git rev-parse HEAD > "$GHOST_TAB_BASELINE_FILE" 2>/dev/null
+fi
+
+# Set terminal/tab title based on tab_title setting
+_tab_title_setting="full"
+_settings_file="${XDG_CONFIG_HOME:-$HOME/.config}/ghost-tab/settings"
+if [ -f "$_settings_file" ]; then
+  _saved_tab_title=$(grep '^tab_title=' "$_settings_file" 2>/dev/null | cut -d= -f2)
+  if [ -n "$_saved_tab_title" ]; then
+    _tab_title_setting="$_saved_tab_title"
+  fi
+fi
+if [ "$_tab_title_setting" = "full" ]; then
+  set_tab_title "$PROJECT_NAME" "$SELECTED_AI_TOOL"
+else
+  set_tab_title "$PROJECT_NAME"
+fi
+
+# Background watcher: switch to Claude pane once it's ready
+(
+  while true; do
+    sleep 0.5
+    content=$("$TMUX_CMD" capture-pane -t "$SESSION_NAME:0.1" -p 2>/dev/null)
+    # All three tools show a prompt character when ready
+    if echo "$content" | grep -qE '[>$❯]'; then
+      "$TMUX_CMD" select-pane -t "$SESSION_NAME:0.1"
+      break
+    fi
+  done
+) &
+WATCHER_PID=$!
+
+cleanup() {
+  cleanup_tmux_session "$SESSION_NAME" "$WATCHER_PID" "$TMUX_CMD"
+  rm -f "$GHOST_TAB_BASELINE_FILE"
+}
+trap cleanup EXIT HUP TERM INT
+
+# Build the AI tool launch command
+case "$SELECTED_AI_TOOL" in
+  codex|opencode)
+    AI_LAUNCH_CMD="$(build_ai_launch_cmd "$SELECTED_AI_TOOL" "$CLAUDE_CMD" "$CODEX_CMD" "$COPILOT_CMD" "$OPENCODE_CMD" "$PROJECT_DIR")"
+    ;;
+  *)
+    AI_LAUNCH_CMD="$(build_ai_launch_cmd "$SELECTED_AI_TOOL" "$CLAUDE_CMD" "$CODEX_CMD" "$COPILOT_CMD" "$OPENCODE_CMD" "$*")"
+    ;;
+esac
+
+"$TMUX_CMD" new-session -s "$SESSION_NAME" -e "PATH=$PATH" -e "GHOST_TAB_BASELINE_FILE=$GHOST_TAB_BASELINE_FILE" -c "$PROJECT_DIR" \
+  "$LAZYGIT_CMD; exec bash" \; \
+  set-option status-left " ⬡ ${PROJECT_NAME} " \; \
+  set-option status-left-style "fg=white,bg=colour236,bold" \; \
+  set-option status-style "bg=colour235" \; \
+  set-option status-right "" \; \
+  set-option exit-unattached on \; \
+  split-window -h -p 50 -c "$PROJECT_DIR" \
+  "$AI_LAUNCH_CMD; exec bash" \; \
+  select-pane -t 0 \; \
+  split-window -v -p 50 -c "$PROJECT_DIR" \
+  "trap exit TERM; while true; do $BROOT_CMD $PROJECT_DIR; done" \; \
+  split-window -v -p 30 -c "$PROJECT_DIR" \; \
+  select-pane -t 3


### PR DESCRIPTION
## Summary

- **Terminal-agnostic architecture**: Ghost Tab now supports Ghostty, iTerm2, WezTerm, and kitty via a Terminal Adapter Pattern. Each terminal gets an adapter module (`lib/terminals/`) implementing a common interface for config setup, installation, and cleanup.
- **`ghost-tab --terminal` flag**: Switch or add a terminal without re-running the full setup wizard. Keeps all existing settings intact.
- **Worktree creation UI**: Add worktrees from the project menu via branch picker TUI, with branch filtering and deletion support.
- **Terminal selection TUI**: New Go Bubbletea component and CLI subcommand for interactive terminal selection during setup.
- **Wrapper renamed**: `ghostty/claude-wrapper.sh` → `wrapper.sh` at unified location `~/.config/ghost-tab/wrapper.sh`.
- **Backward compatibility**: Auto-detects legacy Ghostty-only installations and migrates preferences.

## New Files

- `lib/terminals/registry.sh`, `adapter.sh`, `ghostty.sh`, `kitty.sh`, `wezterm.sh`, `iterm2.sh`
- `lib/terminal-select-tui.sh`
- `wrapper.sh`, `terminals/ghostty/config`, `terminals/kitty/config`, `terminals/wezterm/config.lua`
- `internal/models/terminal.go`, `internal/tui/terminal_selector.go`, `cmd/ghost-tab-tui/select_terminal.go`
- 9 new test files (~49 new tests)

## Test plan

- [x] Full test suite passes (9 packages)
- [x] shellcheck clean on all new/modified scripts
- [x] All 4 terminal adapters tested (setup, merge, replace, cleanup)
- [x] Terminal selector TUI tested (selection, cancellation, edge cases)
- [x] `--terminal` flag argument parsing tested
- [x] Existing ghostty-config tests still pass (backward compat)
- [x] `wrapper.sh` byte-identical to original `ghostty/claude-wrapper.sh`