### PR TITLE
perf: faster agent launch

### DIFF
--- a/lib/ai-tools.sh
+++ b/lib/ai-tools.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 # AI tool helper functions — pure, no side effects on source.
 
+# Resolve the command used to launch OpenCode, optimized for launch speed.
+#
+# `npx opencode-ai@latest` revalidates against the npm registry on every launch
+# (~6s warm) and reinstalls the whole package whenever a new version is published
+# (~46s). A directly-installed `opencode` binary launches in ~2s with no npm work,
+# so it is preferred whenever present. When only npx is available, the fallback
+# adds --prefer-offline so the existing npx cache is reused (skipping the registry
+# round-trip and the periodic reinstall) instead of `@latest` re-fetching.
+#
+# Echoes the launch command, or empty when neither opencode nor npx is on PATH.
+resolve_opencode_cmd() {
+  if command -v opencode &>/dev/null; then
+    echo "opencode"
+  elif command -v npx &>/dev/null; then
+    echo "npx --prefer-offline opencode-ai@latest"
+  fi
+}
+
 # Validates SELECTED_AI_TOOL against AI_TOOLS_AVAILABLE.
 # Falls back to first available if current selection is invalid.
 # Optional arg $1: path to preference file (writes corrected value if provided).

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -199,12 +199,33 @@ ensure_nerd_font() {
   return 0
 }
 
-# Ensure OpenCode is available via npx, removing any brew-installed version first.
+# Ensure OpenCode is available, preferring a directly-installed binary.
+#
+# A real `opencode` binary launches ~3x faster than `npx opencode-ai@latest`,
+# which revalidates against the npm registry on every launch and reinstalls the
+# whole package (~46s) on every version bump. So install it globally via npm when
+# possible; fall back to npx (the wrapper uses --prefer-offline) only when a
+# global install is unavailable or fails. Any brew-installed copy is removed
+# first so npm is the single source of truth.
 ensure_opencode() {
   # Remove brew-installed opencode if present
   if brew list opencode &>/dev/null; then
     info "Removing brew-installed OpenCode..."
     brew uninstall opencode &>/dev/null || true
+  fi
+
+  if command -v opencode &>/dev/null; then
+    success "OpenCode already installed"
+    return 0
+  fi
+
+  if command -v npm &>/dev/null; then
+    info "Installing OpenCode..."
+    if npm install -g opencode-ai &>/dev/null; then
+      success "OpenCode installed"
+      return 0
+    fi
+    warn "Global OpenCode install failed — falling back to npx (slower launches)"
   fi
 
   if command -v npx &>/dev/null; then

--- a/lib/notification-setup.sh
+++ b/lib/notification-setup.sh
@@ -39,6 +39,16 @@ setup_sound_notification() {
 set_claude_notif_channel() {
   local config_dir="$1"
   local settings_path="${2:-$HOME/.claude/settings.json}"
+  # Fast path: when the channel is already terminal_bell (set by this or another
+  # live session), the python below immediately sys.exit(0) without writing — but
+  # still pays a ~40ms cold start on every Claude launch, ahead of the AI tool
+  # starting. Detect the already-silenced state with a cheap grep and skip the
+  # spawn (and the mkdir). Mirrors the python's `if current == "terminal_bell":
+  # sys.exit(0)`, so the saved prev value is left untouched exactly as before.
+  if [ -f "$settings_path" ] \
+    && grep -qE '"preferredNotifChannel"[[:space:]]*:[[:space:]]*"terminal_bell"' "$settings_path"; then
+    return 0
+  fi
   mkdir -p "$config_dir"
   python3 - "$settings_path" "$config_dir/prev-notif-channel" << 'PYEOF'
 import json, os, sys

--- a/lib/screenshot.sh
+++ b/lib/screenshot.sh
@@ -10,6 +10,51 @@
 # lets a tmux binding inject the latest screenshot straight into the AI pane,
 # bypassing drop routing entirely.
 
+# _gt_bin_signature <path> — print a stable per-binary signature (path + mtime +
+# size) used to invalidate the cached capability probe when the binary changes.
+# stat flags differ between BSD (macOS) and GNU; try BSD first.
+_gt_bin_signature() {
+  local f="$1" meta
+  meta="$(stat -f '%m-%z' "$f" 2>/dev/null || stat -c '%Y-%s' "$f" 2>/dev/null)"
+  printf '%s@%s' "$f" "$meta"
+}
+
+# gt_claude_filter_prefix <cache_dir> — print the screenshot-filter launch prefix
+# ("wisp-deck-tui screenshot-filter -- ") when the installed TUI binary supports
+# the subcommand, else print nothing. Probing spawns the Go binary (~40ms) and
+# runs synchronously on every Claude launch before the AI tool can start. A
+# binary's capabilities are fixed, so the result is cached keyed by the binary's
+# path+mtime+size: only the first launch after an install/update pays the probe.
+# Always returns 0 so a failed probe never aborts the launch.
+gt_claude_filter_prefix() {
+  local cache_dir="$1" bin
+  bin="$(command -v wisp-deck-tui 2>/dev/null)" || return 0
+  [ -n "$bin" ] || return 0
+
+  local sig cache_file cached
+  sig="$(_gt_bin_signature "$bin")"
+  cache_file="$cache_dir/screenshot-filter-capable"
+
+  if [ -f "$cache_file" ]; then
+    IFS= read -r cached < "$cache_file" 2>/dev/null || cached=""
+    case "$cached" in
+      "${sig}|1") printf 'wisp-deck-tui screenshot-filter -- '; return 0 ;;
+      "${sig}|0") return 0 ;;
+    esac
+  fi
+
+  # Cache miss (first run, or the binary changed): probe once and record the
+  # verdict so later launches skip the spawn.
+  mkdir -p "$cache_dir"
+  if wisp-deck-tui screenshot-filter -- true >/dev/null 2>&1; then
+    printf '%s|1\n' "$sig" > "$cache_file"
+    printf 'wisp-deck-tui screenshot-filter -- '
+  else
+    printf '%s|0\n' "$sig" > "$cache_file"
+  fi
+  return 0
+}
+
 # gt_screenshot_dir — print the directory macOS saves screenshots to.
 # Honors `com.apple.screencapture location`; falls back to ~/Desktop.
 gt_screenshot_dir() {

--- a/lib/settings-json.sh
+++ b/lib/settings-json.sh
@@ -30,6 +30,22 @@ CSEOF
 # Outputs "added", "upgraded", or "exists".
 add_waiting_indicator_hooks() {
   local path="$1"
+  # Fast path: a python3 cold start (~40ms) runs synchronously on every Claude
+  # launch before the AI tool can start. When the file already carries all three
+  # distinguishing markers of the current format — the PostToolUse "-cooldown"
+  # hook, the AskUserQuestion "-ask" sidecar, and the catch-all negative-lookahead
+  # matcher — the python below would only print "exists" and write nothing. These
+  # three substrings are exactly the upgrade targets, so their joint presence is a
+  # conservative subset of python's "exists" condition: no older format has all of
+  # them. Skip the spawn (and the mkdir/dirname subshells) entirely in that common
+  # case. Runs before mkdir because the check only reads an existing file.
+  if [ -f "$path" ] \
+    && grep -q -- '-cooldown' "$path" \
+    && grep -q -- '-ask' "$path" \
+    && grep -qF '(?!AskUserQuestion$)' "$path"; then
+    echo "exists"
+    return 0
+  fi
   mkdir -p "$(dirname "$path")"
   python3 - "$path" << 'PYEOF'
 import json, sys, os

--- a/test/bash/install_test.go
+++ b/test/bash/install_test.go
@@ -449,25 +449,63 @@ func TestEnsureNerdFont_gracefully_warns_when_brew_fails(t *testing.T) {
 // ensure_opencode tests
 // ============================================================
 
-func TestEnsureOpencode_ready_when_npx_available_and_not_from_brew(t *testing.T) {
+// A directly-installed `opencode` binary launches ~3x faster than
+// `npx opencode-ai@latest` (no per-launch registry check or reinstall), so the
+// installer installs it globally via npm when possible and only falls back to
+// npx when that is unavailable.
+
+func TestEnsureOpencode_installs_globally_via_npm_when_absent(t *testing.T) {
 	dir := t.TempDir()
-	// Mock npx on PATH
-	binDir := mockCommand(t, dir, "npx", `echo "npx"`)
-	// Mock brew list opencode to fail (not installed via brew)
+	npmLog := filepath.Join(dir, "npm_calls")
+	// opencode is NOT mocked → not yet installed. npm is available.
+	binDir := mockCommand(t, dir, "npm", fmt.Sprintf(`echo "$@" >> %q; exit 0`, npmLog))
 	mockCommand(t, dir, "brew", `exit 1`)
+	symlinkUsrBinTools(t, binDir, "grep", "sed", "tr")
 	snippet := installSnippet(t, `ensure_opencode`)
-	env := buildEnv(t, []string{binDir})
+	env := buildEnv(t, nil, "PATH="+binDir+":/bin")
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "OpenCode installed")
+	npmCalls, _ := os.ReadFile(npmLog)
+	assertContains(t, string(npmCalls), "install -g opencode-ai")
+}
+
+func TestEnsureOpencode_skips_install_when_already_present(t *testing.T) {
+	dir := t.TempDir()
+	npmLog := filepath.Join(dir, "npm_calls")
+	binDir := mockCommand(t, dir, "opencode", `echo opencode`)
+	mockCommand(t, dir, "npm", fmt.Sprintf(`echo "$@" >> %q; exit 0`, npmLog))
+	mockCommand(t, dir, "brew", `exit 1`)
+	symlinkUsrBinTools(t, binDir, "grep", "sed", "tr")
+	snippet := installSnippet(t, `ensure_opencode`)
+	env := buildEnv(t, nil, "PATH="+binDir+":/bin")
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out, "OpenCode already installed")
+	if _, err := os.Stat(npmLog); err == nil {
+		t.Errorf("npm must not run when opencode is already installed")
+	}
+}
+
+func TestEnsureOpencode_falls_back_to_npx_when_npm_install_fails(t *testing.T) {
+	dir := t.TempDir()
+	// npm present but its install fails; npx is available as the fallback.
+	binDir := mockCommand(t, dir, "npm", `exit 1`)
+	mockCommand(t, dir, "npx", `echo npx`)
+	mockCommand(t, dir, "brew", `exit 1`)
+	symlinkUsrBinTools(t, binDir, "grep", "sed", "tr")
+	snippet := installSnippet(t, `ensure_opencode`)
+	env := buildEnv(t, nil, "PATH="+binDir+":/bin")
 	out, code := runBashSnippet(t, snippet, env)
 	assertExitCode(t, code, 0)
 	assertContains(t, out, "OpenCode ready")
 }
 
-func TestEnsureOpencode_warns_when_npx_not_available(t *testing.T) {
+func TestEnsureOpencode_warns_when_no_node(t *testing.T) {
 	dir := t.TempDir()
-	// No npx on PATH — use restricted PATH
+	// Neither npm nor npx on PATH — use restricted PATH.
 	binDir := filepath.Join(dir, "bin")
 	os.MkdirAll(binDir, 0755)
-	// Mock brew list to fail (not from brew)
 	mockCommand(t, dir, "brew", `exit 1`)
 	symlinkUsrBinTools(t, binDir, "grep", "sed", "tr")
 	snippet := installSnippet(t, `ensure_opencode`)
@@ -480,6 +518,7 @@ func TestEnsureOpencode_warns_when_npx_not_available(t *testing.T) {
 func TestEnsureOpencode_removes_brew_opencode(t *testing.T) {
 	dir := t.TempDir()
 	brewLog := filepath.Join(dir, "brew_calls")
+	npmLog := filepath.Join(dir, "npm_calls")
 	// Mock brew: "list opencode" succeeds (installed via brew), log uninstall
 	binDir := mockCommand(t, dir, "brew", fmt.Sprintf(`
 echo "$@" >> %q
@@ -487,8 +526,8 @@ if [ "$1" = "list" ] && [ "$2" = "opencode" ]; then exit 0; fi
 if [ "$1" = "uninstall" ]; then exit 0; fi
 exit 1
 `, brewLog))
-	// Mock npx available
-	mockCommand(t, dir, "npx", `echo "npx"`)
+	// npm available so the (post-removal) global install path runs.
+	mockCommand(t, dir, "npm", fmt.Sprintf(`echo "$@" >> %q; exit 0`, npmLog))
 	symlinkUsrBinTools(t, binDir, "grep", "sed", "tr")
 	snippet := installSnippet(t, `ensure_opencode`)
 	env := buildEnv(t, nil, "PATH="+binDir+":/bin")
@@ -497,5 +536,5 @@ exit 1
 	brewCalls, _ := os.ReadFile(brewLog)
 	assertContains(t, string(brewCalls), "uninstall opencode")
 	assertContains(t, out, "Removing brew-installed OpenCode")
-	assertContains(t, out, "OpenCode ready")
+	assertContains(t, out, "OpenCode installed")
 }

--- a/test/bash/launch_fastpath_test.go
+++ b/test/bash/launch_fastpath_test.go
@@ -1,0 +1,199 @@
+package bash_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests pin the launch-time fast paths that avoid spawning python3 when
+// the relevant settings are already in their final form. A python3 cold start
+// is ~40-90ms; wrapper.sh runs add_waiting_indicator_hooks AND
+// set_claude_notif_channel synchronously on EVERY Claude launch, before the AI
+// tool can start. When settings.json is already current (the common case after
+// the first launch), no rewrite is needed, so python3 must not be invoked at
+// all — shaving that latency off the time-to-agent-ready.
+
+// currentFormatWaitingHooks is a settings.json whose waiting-indicator hooks are
+// already in the current format (Stop + AskUserQuestion -ask sidecar + catch-all
+// negative-lookahead matcher + PostToolUse cooldown). Mirrors the fixture in
+// TestSettingsJson_add_waiting_indicator_hooks_reports_exists_when_duplicate.
+const currentFormatWaitingHooks = `{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [{"type": "command", "command": "if [ -n \"$WISP_DECK_MARKER_FILE\" ]; then touch \"$WISP_DECK_MARKER_FILE\"; fi"}]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [{"type": "command", "command": "if [ -n \"$WISP_DECK_MARKER_FILE\" ]; then touch \"$WISP_DECK_MARKER_FILE\" \"${WISP_DECK_MARKER_FILE}-ask\"; fi"}]
+      },
+      {
+        "matcher": "^(?!AskUserQuestion$)",
+        "hooks": [{"type": "command", "command": "if [ -n \"$WISP_DECK_MARKER_FILE\" ]; then rm -f \"$WISP_DECK_MARKER_FILE\" \"${WISP_DECK_MARKER_FILE}-ask\"; fi"}]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [{"type": "command", "command": "if [ -n \"$WISP_DECK_MARKER_FILE\" ]; then touch \"${WISP_DECK_MARKER_FILE}-cooldown\"; fi"}]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [{"type": "command", "command": "if [ -n \"$WISP_DECK_MARKER_FILE\" ]; then rm -f \"$WISP_DECK_MARKER_FILE\" \"${WISP_DECK_MARKER_FILE}-ask\"; fi"}]
+      }
+    ]
+  }
+}
+`
+
+// pythonProbeEnv returns (env, sentinelPath) where env shadows python3/python
+// with a mock that records its invocation by creating sentinelPath. If the
+// sentinel exists after the call, python3 was spawned.
+func pythonProbeEnv(t *testing.T, tmpDir string) ([]string, string) {
+	t.Helper()
+	sentinel := filepath.Join(tmpDir, "python3-was-called")
+	body := fmt.Sprintf("touch %q\nexit 0", sentinel)
+	binDir := mockCommand(t, tmpDir, "python3", body)
+	// Some code paths may call bare `python`; shadow it too for safety.
+	mockCommand(t, tmpDir, "python", body)
+	return buildEnv(t, []string{binDir}), sentinel
+}
+
+func TestFastPath_add_waiting_indicator_hooks_skips_python_when_current(t *testing.T) {
+	tmpDir := t.TempDir()
+	settingsFile := writeTempFile(t, tmpDir, "settings.json", currentFormatWaitingHooks)
+	before, _ := os.ReadFile(settingsFile)
+
+	env, sentinel := pythonProbeEnv(t, tmpDir)
+	snippet := settingsJsonSnippet(t,
+		fmt.Sprintf(`add_waiting_indicator_hooks %q`, settingsFile))
+	out, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, strings.TrimSpace(out), "exists")
+
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("python3 was spawned even though hooks are already current — fast path should skip it")
+	}
+	after, _ := os.ReadFile(settingsFile)
+	if string(before) != string(after) {
+		t.Error("settings.json was rewritten even though hooks are already current")
+	}
+}
+
+// screenshotLibSnippet sources screenshot.sh then runs body.
+func screenshotLibSnippet(t *testing.T, body string) string {
+	t.Helper()
+	lib := filepath.Join(projectRoot(t), "lib", "screenshot.sh")
+	return fmt.Sprintf("source %q && %s", lib, body)
+}
+
+func TestFastPath_claude_filter_prefix_probes_once_then_caches(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	counter := filepath.Join(tmpDir, "probe-count")
+	// Mock wisp-deck-tui: records each invocation and succeeds (supports filter).
+	binDir := mockCommand(t, tmpDir, "wisp-deck-tui",
+		fmt.Sprintf("echo x >> %q\nexit 0", counter))
+	env := buildEnv(t, []string{binDir})
+
+	snippet := screenshotLibSnippet(t, fmt.Sprintf(`gt_claude_filter_prefix %q`, cacheDir))
+
+	out1, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out1, "wisp-deck-tui screenshot-filter -- ")
+
+	out2, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+	assertContains(t, out2, "wisp-deck-tui screenshot-filter -- ")
+
+	data, _ := os.ReadFile(counter)
+	n := strings.Count(string(data), "x")
+	if n != 1 {
+		t.Errorf("probe ran %d times, want 1 (result should be cached after the first launch)", n)
+	}
+}
+
+func TestFastPath_claude_filter_prefix_reprobes_when_binary_changes(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	counter := filepath.Join(tmpDir, "probe-count")
+	binDir := mockCommand(t, tmpDir, "wisp-deck-tui",
+		fmt.Sprintf("echo x >> %q\nexit 0", counter))
+	env := buildEnv(t, []string{binDir})
+	snippet := screenshotLibSnippet(t, fmt.Sprintf(`gt_claude_filter_prefix %q`, cacheDir))
+
+	runBashSnippet(t, snippet, env)
+	// Simulate an install/update: change the binary's mtime so its signature differs.
+	binPath := filepath.Join(binDir, "wisp-deck-tui")
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(binPath, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	runBashSnippet(t, snippet, env)
+
+	data, _ := os.ReadFile(counter)
+	if n := strings.Count(string(data), "x"); n != 2 {
+		t.Errorf("probe ran %d times, want 2 (a changed binary must be re-probed)", n)
+	}
+}
+
+func TestFastPath_claude_filter_prefix_caches_negative_result(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	counter := filepath.Join(tmpDir, "probe-count")
+	// Mock that does NOT support the subcommand (exits non-zero).
+	binDir := mockCommand(t, tmpDir, "wisp-deck-tui",
+		fmt.Sprintf("echo x >> %q\nexit 1", counter))
+	env := buildEnv(t, []string{binDir})
+	snippet := screenshotLibSnippet(t, fmt.Sprintf(`gt_claude_filter_prefix %q`, cacheDir))
+
+	out1, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0) // helper must not fail the launch
+	if strings.TrimSpace(out1) != "" {
+		t.Errorf("unsupported binary should yield no prefix, got %q", out1)
+	}
+	out2, _ := runBashSnippet(t, snippet, env)
+	if strings.TrimSpace(out2) != "" {
+		t.Errorf("cached negative result should still yield no prefix, got %q", out2)
+	}
+	data, _ := os.ReadFile(counter)
+	if n := strings.Count(string(data), "x"); n != 1 {
+		t.Errorf("probe ran %d times, want 1 (negative result should be cached)", n)
+	}
+}
+
+func TestFastPath_set_claude_notif_channel_skips_python_when_already_silenced(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	os.MkdirAll(configDir, 0755)
+	claudeDir := filepath.Join(tmpDir, "claude")
+	os.MkdirAll(claudeDir, 0755)
+	settingsFile := writeTempFile(t, claudeDir, "settings.json",
+		`{"preferredNotifChannel": "terminal_bell", "model": "opus"}`)
+	before, _ := os.ReadFile(settingsFile)
+
+	env, sentinel := pythonProbeEnv(t, tmpDir)
+	snippet := notificationSnippet(t,
+		fmt.Sprintf(`set_claude_notif_channel %q %q`, configDir, settingsFile))
+	_, code := runBashSnippet(t, snippet, env)
+	assertExitCode(t, code, 0)
+
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("python3 was spawned even though channel is already terminal_bell — fast path should skip it")
+	}
+	after, _ := os.ReadFile(settingsFile)
+	if string(before) != string(after) {
+		t.Error("settings.json was rewritten even though channel is already terminal_bell")
+	}
+	// A second concurrent session must not clobber a previously-saved prev value;
+	// the fast path writes nothing, so no prev file is created here.
+	if _, err := os.Stat(filepath.Join(configDir, "prev-notif-channel")); err == nil {
+		t.Error("prev-notif-channel must not be written when channel is already silenced")
+	}
+}

--- a/test/bash/opencode_cmd_test.go
+++ b/test/bash/opencode_cmd_test.go
@@ -1,0 +1,57 @@
+package bash_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolve_opencode_cmd picks the command used to launch OpenCode. The motivation
+// is launch speed: `npx opencode-ai@latest` revalidates against the npm registry
+// on every launch (~6s warm) and reinstalls the whole package on every version
+// bump (~46s). A directly-installed `opencode` binary launches in ~2s, so it is
+// preferred whenever present. When only npx exists, the fallback adds
+// --prefer-offline so the npx cache is reused instead of hitting the registry.
+
+// ocEnv builds a hermetic env whose PATH is exactly binDir, so command -v sees
+// only the commands the test mocked (no leakage from the real machine PATH).
+func ocEnv(t *testing.T, binDir string) []string {
+	t.Helper()
+	return buildEnv(t, nil, "PATH="+binDir)
+}
+
+func TestResolveOpencodeCmd_prefers_direct_binary(t *testing.T) {
+	dir := t.TempDir()
+	binDir := mockCommand(t, dir, "opencode", `echo opencode "$@"`)
+	// npx also present — the binary must still win.
+	mockCommand(t, dir, "npx", `echo npx "$@"`)
+
+	out, code := runBashFunc(t, "lib/ai-tools.sh", "resolve_opencode_cmd", nil, ocEnv(t, binDir))
+	assertExitCode(t, code, 0)
+	if got := strings.TrimSpace(out); got != "opencode" {
+		t.Errorf("got %q, want %q", got, "opencode")
+	}
+}
+
+func TestResolveOpencodeCmd_falls_back_to_prefer_offline_npx(t *testing.T) {
+	dir := t.TempDir()
+	binDir := mockCommand(t, dir, "npx", `echo npx "$@"`)
+
+	out, code := runBashFunc(t, "lib/ai-tools.sh", "resolve_opencode_cmd", nil, ocEnv(t, binDir))
+	assertExitCode(t, code, 0)
+	if got := strings.TrimSpace(out); got != "npx --prefer-offline opencode-ai@latest" {
+		t.Errorf("got %q, want %q", got, "npx --prefer-offline opencode-ai@latest")
+	}
+}
+
+func TestResolveOpencodeCmd_empty_when_neither_present(t *testing.T) {
+	dir := t.TempDir()
+	// An empty bin dir: neither opencode nor npx on PATH.
+	emptyBin := filepath.Join(dir, "empty")
+	mockCommand(t, dir, "placeholder", `:`) // creates dir/bin; we point PATH elsewhere
+	out, code := runBashFunc(t, "lib/ai-tools.sh", "resolve_opencode_cmd", nil, ocEnv(t, emptyBin))
+	assertExitCode(t, code, 0)
+	if got := strings.TrimSpace(out); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -267,9 +267,10 @@ export WISP_DECK_PLAN
 # the installed TUI binary supports the subcommand, so an older binary safely
 # falls back to launching Claude directly.
 WISP_DECK_CLAUDE_FILTER=""
-if [ "$SELECTED_AI_TOOL" = "claude" ] && command -v wisp-deck-tui &>/dev/null \
-  && wisp-deck-tui screenshot-filter -- true >/dev/null 2>&1; then
-  WISP_DECK_CLAUDE_FILTER="wisp-deck-tui screenshot-filter -- "
+if [ "$SELECTED_AI_TOOL" = "claude" ]; then
+  # Capability is cached per binary, so only the first launch after an
+  # install/update pays the ~40ms probe. See gt_claude_filter_prefix.
+  WISP_DECK_CLAUDE_FILTER="$(gt_claude_filter_prefix "$SHARE_DIR")"
 fi
 export WISP_DECK_CLAUDE_FILTER
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -63,11 +63,7 @@ unset _gt_libs _gt_lib
 TMUX_CMD="$(command -v tmux)"
 LAZYGIT_CMD="$(command -v lazygit)"
 CLAUDE_CMD="$(command -v claude)"
-if command -v npx &>/dev/null; then
-  OPENCODE_CMD="npx opencode-ai@latest"
-else
-  OPENCODE_CMD=""
-fi
+OPENCODE_CMD="$(resolve_opencode_cmd)"
 
 # AI tool preference
 AI_TOOL_PREF_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/wisp-deck/ai-tool"


### PR DESCRIPTION
## Summary
Speeds up the AI tool launch critical path.

- **claude**: skip `python3` and probe spawns on the launch critical path
- **opencode**: prefer a direct binary over `npx` for faster launches

## Changes
- `lib/ai-tools.sh`, `lib/install.sh`, `lib/settings-json.sh`, `lib/notification-setup.sh`, `lib/screenshot.sh`, `wrapper.sh`
- Tests: `test/bash/launch_fastpath_test.go`, `test/bash/opencode_cmd_test.go`, `test/bash/install_test.go`

## Testing
- `shellcheck` clean (only benign SC1091 source-directive info)
- Full `./run-tests.sh` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)